### PR TITLE
fix(frontend): pin ws ≥ 8.20.1 via npm overrides (alert #58)

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -18574,28 +18574,6 @@
         "node": ">= 10"
       }
     },
-    "node_modules/webpack-bundle-analyzer/node_modules/ws": {
-      "version": "7.5.10",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.10.tgz",
-      "integrity": "sha512-+dbF1tHwZpXcbOJdVOkzLDxZP1ailvSxM6ZweXTegylPny803bFhA+vqBYw4s31NSAk4S2Qz+AKXK9a4wkdjcQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8.3.0"
-      },
-      "peerDependencies": {
-        "bufferutil": "^4.0.1",
-        "utf-8-validate": "^5.0.2"
-      },
-      "peerDependenciesMeta": {
-        "bufferutil": {
-          "optional": true
-        },
-        "utf-8-validate": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/webpack-sources": {
       "version": "3.3.3",
       "resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-3.3.3.tgz",
@@ -18904,9 +18882,9 @@
       "license": "ISC"
     },
     "node_modules/ws": {
-      "version": "8.19.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.19.0.tgz",
-      "integrity": "sha512-blAT2mjOEIi0ZzruJfIhb3nps74PRWTCz1IjglWEEpQl5XS/UNama6u2/rjFkDDouqr4L67ry+1aGIALViWjDg==",
+      "version": "8.20.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.1.tgz",
+      "integrity": "sha512-It4dO0K5v//JtTXuPkfEOaI3uUN87iYPnqo/ZzqCoG3g8uhA66QUMs/SrM0YK7/NAu+r4LMh/9dq2A7k+rHs+w==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -96,6 +96,7 @@
     "typescript": "^5.7.2"
   },
   "overrides": {
-    "postcss": "^8.5.10"
+    "postcss": "^8.5.10",
+    "ws": "^8.20.1"
   }
 }


### PR DESCRIPTION
## Summary

Closes Dependabot alert #58 — CVE-2026-45736 / GHSA-58qx-3vcg-4xpx (ws@8.0.0–8.20.0, **medium**).

**Why was it open?** `ws@8.19.0` came in transitively through `jest-environment-jsdom` → `jsdom` (test tooling only — not a production runtime dep). Auto-dismissed by Dependabot because direct bumping a transitive dep isn't possible; needs an npm override.

**Fix:** add `"ws": "^8.20.1"` to `frontend/package.json` `overrides`. This also coincidentally lifts the unrelated `ws@7.5.10` instance under `@next/bundle-analyzer` → `webpack-bundle-analyzer` to `8.20.1` (v7 was outside the vulnerable range; consolidation simplifies the lock).

**Verification:**
```
$ npm ls ws
inf-sys-secretary-methodist-frontend@0.153.6
├─┬ @next/bundle-analyzer@16.1.6
│ └─┬ webpack-bundle-analyzer@4.10.1
│   └── ws@8.20.1
└─┬ jest-environment-jsdom@29.7.0
  └─┬ jsdom@20.0.3
    └── ws@8.20.1 deduped
```

Jest smoke test passes (jsdom is the only runtime ws consumer in tests).

## Test plan

- [x] `npm ls ws` reports only `8.20.1` (no `8.19.0` remaining)
- [x] `npx jest` smoke (`appearanceStore.test.ts`) passes
- [x] No production code changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)