### PR TITLE
fix(frontend): pin @tootallnate/once ≥ 3.0.1 via npm overrides (#12)

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -6426,9 +6426,9 @@
       }
     },
     "node_modules/@tootallnate/once": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-2.0.1.tgz",
-      "integrity": "sha512-HqmEUIGRJ5fSXchkVgR5F7qn48bDBzv0kWj/Kfu5e6uci4UlEeng4331LnBkWffb++Ei3FOVLxo8JJWMFBDMeQ==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-3.0.1.tgz",
+      "integrity": "sha512-VyMVKRrpHTT8PnotUeV8L/mDaMwD5DaAKCFLP73zAqAtvF0FCqky+Ki7BYbFCYQmqFyTe9316Ed5zS70QUR9eg==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -97,6 +97,7 @@
   },
   "overrides": {
     "postcss": "^8.5.10",
-    "ws": "^8.20.1"
+    "ws": "^8.20.1",
+    "@tootallnate/once": "^3.0.1"
   }
 }


### PR DESCRIPTION
## Summary
Closes Dependabot alert **#12** — `@tootallnate/once@2.0.1` (GHSA-vpq2-c234-7xj6, low severity, "Incorrect Control Flow Scoping"). Fixed in 3.0.1.

## Why
- Transitive chain (test tooling only, **not prod runtime**):
  `jest-environment-jsdom@29.7.0` → `jsdom@20.0.3` → `http-proxy-agent@5.0.0` → `@tootallnate/once@2.0.1`
- Dependabot's auto-PR #211 attempted to **remove** the package (since 3.0.1 isn't pulled directly) — would break jest. PR was closed unmerged.
- Mirror к ws@8.20.1 override pattern shipped в PR #251 (Phase 6 lesson — same dev-only transitive vuln class).

## Fix
Added override:
```json
"overrides": {
  "postcss": "^8.5.10",
  "ws": "^8.20.1",
  "@tootallnate/once": "^3.0.1"
}
```

## Verify
- `npm install` → success, 0 vulnerabilities reported
- `npm ls @tootallnate/once` → single deduped `3.0.1` across full chain
- GitHub alert #12 flips к `fixed` ~5s after merge (per ws lesson)

🤖 Generated with [Claude Code](https://claude.com/claude-code)