### PR TITLE
fix(ci): husky pre-commit bash 3.2 compatibility on macOS default shell

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -22,7 +22,11 @@ cd "$REPO_ROOT"
 
 # Resolve staged files (Added / Copied / Modified) — skip Deleted so
 # linters don't see paths that no longer exist.
-mapfile -t STAGED < <(git diff --cached --name-only --diff-filter=ACM)
+# NB: `while read` instead of `mapfile` (bash 4+) — macOS ships bash 3.2.
+STAGED=()
+while IFS= read -r line; do
+    STAGED+=("$line")
+done < <(git diff --cached --name-only --diff-filter=ACM)
 [[ ${#STAGED[@]} -eq 0 ]] && exit 0
 
 STAGED_GO=()


### PR DESCRIPTION
## Summary

Pre-commit hook used \`mapfile\` (bash 4+ builtin), which fails on default macOS bash 3.2 under \`set -u\`:

\`\`\`
.husky/pre-commit: line 25: mapfile: command not found
.husky/pre-commit: line 26: STAGED: unbound variable
.husky/pre-commit: line 41: STAGED[@]: unbound variable
\`\`\`

## Why macOS has old bash

Apple froze \`/bin/bash\` at 3.2.57 (2007) because bash 4.0+ switched to GPLv3 — Apple won't ship GPLv3 code due to patent grant concerns. Default shell on macOS Catalina+ is zsh; bash stays at 3.2 for backward compat.

## Fix

Replace \`mapfile -t STAGED < <(...)\` with portable while-read loop. Identical behavior, works on default macOS install without requiring brew/nix bash.

\`\`\`bash
STAGED=()
while IFS= read -r line; do
    STAGED+=("\$line")
done < <(git diff --cached --name-only --diff-filter=ACM)
\`\`\`

## Verification

- [x] Hook ran successfully on its own commit (verified locally)
- [x] Bash 3.2 syntax check: \`bash -c 'STAGED=(); while IFS= read -r line; do STAGED+=("\$line"); done < <(printf "a\nb\nc\n"); echo "count=\${#STAGED[@]}"'\` → \`count=3\`