### PR TITLE
feat(files): v0.161.0-A — AuthorizeFileAccess foundation + ADR-1 IDOR core (split 1/3)

### DIFF
--- a/docs/plans/2026-05-23-v0161-files-security.md
+++ b/docs/plans/2026-05-23-v0161-files-security.md
@@ -1,0 +1,134 @@
+# Plan — v0.161.0 files Tier 1 security hotfix
+
+**Date**: 2026-05-23
+**Module**: `internal/modules/files`
+**Audit verdict**: REJECT mean 4.4 / min 2 — see `docs/plans/2026-05-20-v1.0.0-batch2-audit.md` §files (worst module of batch 2)
+**Batch 2 progress**: 3/5 (after this release; auth ✅ v0.159.0 + users ✅ v0.160.0 already shipped)
+**Issue**: [#290](https://github.com/inf-sys-secretary-methodologist/inf-sys-secretary-methodist/issues/290)
+**Branch**: `hotfix/issue-290-v0161-files-security`
+
+## Scope — 5 ADRs (4 TIER 0 + 1 Tier 1 elevated)
+
+### ADR-1 — Cross-user file enumeration + IDOR (TIER 0)
+
+**Threat**: `GetFile`/`GetFileWithDownloadURL`/`DownloadFile`/`AttachFile` принимают только `id int64`. NO `actorID` arg, no ownership check. Sequential BIGSERIAL → enumerate + download every file ever uploaded (HR records, exam reports, diploma drafts). 1-hour MinIO presigned URL is anonymous external sharing surface.
+
+**Files**: `file_usecase.go:117-206` (GetFile/GetFileWithDownloadURL/DownloadFile/AttachFile), `file_handler.go` (routes), `file_metadata.go` (entity — `UploadedBy` exists)
+
+**Fix**:
+- New domain free function `AuthorizeFileAccess(actorID int64, actorRole string, file *FileMetadata, action FileAction) error` in `files/domain/`. Read actions: actor==uploader OR system_admin. Write actions (Attach/DeleteVersion/CreateVersion): actor==uploader only (no admin override — uploaders are the only legit mutators; admin can read but not impersonate).
+- `FileAction` typed enum: `FileActionRead`, `FileActionAttach`, `FileActionCreateVersion`, `FileActionDelete`.
+- Usecase signatures: `GetFile(ctx, id, actorID, actorRole)`, `DownloadFile(ctx, id, actorID, actorRole)`, `GetFileWithDownloadURL(ctx, id, urlExpiration, actorID, actorRole)`, `AttachFile(ctx, input)` — input.UserID & input.UserRole already exist в `AttachFileInput`, just enforce.
+- Handler reads `actorID := c.Get("user_id")`, `role := c.Get("role")`, passes through.
+- Sentinel `ErrFileAccessDenied` (var Err* — `*PermissionError` struct → migrate to var sentinel; closes Tier 1 DDD-9 absorb partially).
+- Handler maps → 403 с stable error code `file_access_denied`.
+- Audit denial: emit `file_access_denied` с `actor_user_id`, `target_file_id`, `action`, `reason` (mirror v0.160.0 ADR-4 pattern).
+
+**RED test** (table-driven):
+- (read, actor=uploader) → allow
+- (read, actor=other, role=student) → ErrFileAccessDenied + audit denial
+- (read, actor=other, role=system_admin) → allow
+- (attach, actor=uploader) → allow
+- (attach, actor=other, role=system_admin) → ErrFileAccessDenied (no admin override on write)
+- (delete, actor=uploader) → allow
+- (delete, actor=other) → ErrFileAccessDenied
+
+### ADR-2 — CreateVersion ownership hijack (TIER 0)
+
+**Threat**: `version_usecase.go:48-108` — CreateVersion looks up file but only checks `IsTemporary`. Anyone pushes new version в anyone's file. UI shows latest = attacker-controlled (defacement + supply-chain).
+
+**Files**: `version_usecase.go:48-108`, `file_handler.go` (CreateVersion route)
+
+**Fix**:
+- CreateVersion calls `AuthorizeFileAccess(actorID, actorRole, file, FileActionCreateVersion)` BEFORE проверки `IsTemporary` (fail-fast on auth).
+- `CreateVersionInput.UserID` already exists; add `UserRole string` для polymorphic admin override consistency (но admin не permitted на write per ADR-1 — argument kept for symmetry, will always fail-deny на non-uploader).
+- Sentinel: same `ErrFileAccessDenied` (reused).
+- Handler maps → 403.
+- Audit denial: same pattern (`file_version_create_denied`).
+- Bonus: sanitize `Comment` через `SanitizeString` (closes Tier 1 #8 stored XSS).
+
+**RED test**:
+- (uploader creates version) → ok
+- (other student creates version) → ErrFileAccessDenied + audit denial
+- (system_admin creates version в чужом файле) → ErrFileAccessDenied (no admin write override)
+- (comment с `<script>`) → sanitized в version row
+
+### ADR-3 — DEAD `FileValidator.ValidateFile` wire-in (TIER 0)
+
+**Threat**: `file_validator.go:99-164` (MIME whitelist + magic bytes sniff + size cap + extension whitelist) wired в `main.go:778-803`, но usecase calls only `ValidateFileName` (cosmetic sanitization). Upload `evil.exe` с `Content-Type: application/octet-stream` succeeds. Magic-byte detection / MIME whitelist / size cap entirely BYPASSED.
+
+**Files**: `file_usecase.go:55-115` (UploadFile), `storage.go` (interface), `file_validator.go` (shared)
+
+**Fix**:
+- Narrow port в `files/application/usecases/storage.go`: `type FileValidator interface { ValidateFile(ctx, header *multipart.FileHeader, reader io.Reader) (*ValidationResult, error); ValidateFileName(string) (string, error) }` — both methods, не только ValidateFileName.
+- UploadFile signature accepts `*multipart.FileHeader` for header validation (size + MIME from Content-Type header) OR struct DTO `ValidateInput { Name string; Size int64; DeclaredMIME string }` if multipart-coupling is too tight. Choose **DTO option** to keep usecase pure (Clean Architecture).
+- Call sequence: `ValidateFileName` → `ValidateFile` (full pipeline, reading sniff bytes без consuming reader через `bufio.Reader.Peek` or tee).
+- `evil.exe` test: declared MIME `application/octet-stream` + first bytes 4D 5A (PE) → reject with `ErrFileTypeForbidden`.
+
+**RED test** (table-driven, reader-based):
+- Valid PDF (magic %PDF-) declared `application/pdf` → ok
+- evil.exe (4D 5A magic, declared octet-stream) → ErrFileTypeForbidden
+- 100MB file (size > 50MB cap) → ErrFileSizeExceeded
+- HTML disguised as image (declared image/png, magic <html) → ErrMimeMismatch
+
+### ADR-4 — Extract `IsInlineSafeMime` + `BuildContentDisposition` к shared pkg (Tier 1 elevated)
+
+**Threat**: No clickjacking protection — raw MinIO presigned URL with original `Content-Type`. v0.156.0 documents hardening (`IsInlineSafeMime` + `BuildContentDisposition`) не применяется к files module. HTML/SVG uploaded as `text/html` opens inline → XSS / framejacking surface.
+
+**Current location**: `internal/modules/documents/interfaces/http/handlers/inline_mime.go` + `content_disposition.go`.
+
+**Files**: extract to `internal/shared/infrastructure/http/headers/` — `inline_mime.go` + `content_disposition.go` + `rfc2231.go` (filename encoder); update documents callers (import path change); files DownloadResponse adds `ContentDisposition` field, handler sets header.
+
+**Fix**:
+- New shared pkg `internal/shared/infrastructure/http/headers/` (or similar) — pure functions, zero deps beyond stdlib.
+- Documents handler imports change.
+- Files Download (`file_handler.go`) returns presigned URL **plus** safe Content-Disposition header (`attachment; filename*=UTF-8''<encoded>` for non-inline MIME, `inline; filename*=...` for whitelisted inline like image/pdf).
+- Files Version Download same treatment.
+
+**RED test**:
+- `IsInlineSafeMime("image/png")` → true
+- `IsInlineSafeMime("text/html")` → false (force download)
+- `IsInlineSafeMime("application/pdf")` → true (с separate sandbox header) — match v0.156.0 behavior
+- `BuildContentDisposition("файл.pdf", "application/pdf")` → `inline; filename*=UTF-8''%D1%84%D0%B0%D0%B9%D0%BB.pdf` exact match
+
+### ADR-5 — `/api/files/cleanup` admin gate (Tier 1)
+
+**Threat**: `main.go:2703` route registers `POST /api/files/cleanup` WITHOUT `RequireRole(system_admin)`. Handler comment "Доступ должен быть ограничен администраторам" — security-by-comment.
+
+**Files**: `main.go:2703`, `file_handler.go:368-384` (handler), `routes.go` (if exists)
+
+**Fix**:
+- Apply `RequireRole(SystemAdmin)` middleware к route — mirror v0.133.0 `usersAdminMW` pattern + v0.160.0 ADR-2 (departments/positions).
+- Handler comment removed (no longer authoritative).
+
+**RED test**: student JWT POST `/api/files/cleanup` → 403 at middleware boundary; admin JWT → 200.
+
+## Tier 2 deferred к v0.161.1 (per `feedback_tier2_absorb_same_release` ≤4 cap; v0.161.0 absorbs only minimal-cost cleanups)
+
+1. DIP relocation — `files/domain/repositories/` → `files/application/usecases/` (mirror v0.157.1, v0.160.1)
+2. `*ValidationError` → `var ErrFileValidation` (other ValidationError struct types в module)
+3. `MaxBytesReader` wrapper на upload route (DoS mitigation)
+4. Per-user quota for uploads
+5. UI strings extraction (Russian errors in usecase → handler/messages package)
+6. Concrete `*storage.S3Client` → narrow port в constructor signature
+7. `Files`/`Users interface{}` untyped slices в DTOs → typed slices
+
+(7 items mirror v0.155→.1, v0.157→.1, v0.160→.1 split precedent — likely ship v0.161.1 within 1-2 sessions of v0.161.0 SHIP.)
+
+## Reviewer trajectory expectation
+
+- Round 1: FIX-CYCLE 5.x/4 (worst module — 4 TIER 0, expect Tests/DDD axis dips)
+- Round 2: FIX-CYCLE 7.x/6 (absorbs landed, may surface Tier 2 escalations or test-coverage gaps for round-1 absorbs)
+- Round 3: SHIP ≥8/8 (mirror v0.160.0 trajectory)
+
+**Tests-axis discipline (v0.160.0 lesson)**: every FIX-CYCLE absorb behavior change gets RED→GREEN pair within absorb, не "patching gap of original RED".
+
+## Release ritual (mechanical, ~30-60min after SHIP)
+
+1. `bash _tools/bump_version.sh 0.161.0` (8 files)
+2. Explicit stage version-bump files (per `feedback_explicit_stage_for_release`)
+3. Release commit `fix(files): v0.161.0 — Tier 1 security hotfix (closes #XXX)` (NOT `release(files)` — Validate PR Metadata)
+4. Push + PR + likely admin-merge при >1000 LOC (precedent v0.158/v0.159/v0.160)
+5. **STICKY**: `git tag -a v0.161.0` + `git push origin v0.161.0` + `gh release create v0.161.0` IMMEDIATELY post-merge
+6. Docs PR `docs/roles-and-flows.md` refresh — banner 0.160.0 → 0.161.0 + batch 2 progress 3/5
+7. Memory artifacts: `project_v0161_0_files_security.md` (auto-memory) + MEMORY.md index + chronicles entry + handoff + `memory/context/workspace.md`

--- a/internal/modules/files/application/dto/file_dto.go
+++ b/internal/modules/files/application/dto/file_dto.go
@@ -1,7 +1,11 @@
 // Package dto содержит объекты передачи данных модуля files.
 package dto
 
-import "time"
+import (
+	"time"
+
+	authDomain "github.com/inf-sys-secretary-methodologist/inf-sys-secretary-methodist/internal/modules/auth/domain"
+)
 
 // UploadFileInput представляет входные данные для загрузки файла.
 type UploadFileInput struct {
@@ -12,18 +16,25 @@ type UploadFileInput struct {
 }
 
 // AttachFileInput представляет входные данные для прикрепления файла.
+//
+// UserID and UserRole are populated from auth middleware context and are
+// required for the ownership guard in AttachFile — they intentionally
+// have `json:"-"` so they cannot be overridden by request payload.
 type AttachFileInput struct {
-	FileID         int64  `json:"file_id" validate:"required"`
-	DocumentID     *int64 `json:"document_id"`
-	TaskID         *int64 `json:"task_id"`
-	AnnouncementID *int64 `json:"announcement_id"`
+	FileID         int64               `json:"file_id" validate:"required"`
+	DocumentID     *int64              `json:"document_id"`
+	TaskID         *int64              `json:"task_id"`
+	AnnouncementID *int64              `json:"announcement_id"`
+	UserID         int64               `json:"-"` // Заполняется из контекста авторизации
+	UserRole       authDomain.RoleType `json:"-"` // Заполняется из контекста авторизации
 }
 
 // CreateVersionInput представляет входные данные для создания версии файла.
 type CreateVersionInput struct {
-	FileID  int64  `json:"file_id" validate:"required"`
-	Comment string `json:"comment" validate:"omitempty,max=500"`
-	UserID  int64  `json:"-"` // Заполняется из контекста авторизации
+	FileID   int64               `json:"file_id" validate:"required"`
+	Comment  string              `json:"comment" validate:"omitempty,max=500"`
+	UserID   int64               `json:"-"` // Заполняется из контекста авторизации
+	UserRole authDomain.RoleType `json:"-"` // Заполняется из контекста авторизации
 }
 
 // FileResponse представляет ответ с информацией о файле.

--- a/internal/modules/files/application/usecases/file_usecase.go
+++ b/internal/modules/files/application/usecases/file_usecase.go
@@ -10,6 +10,8 @@ import (
 	"io"
 	"time"
 
+	authDomain "github.com/inf-sys-secretary-methodologist/inf-sys-secretary-methodist/internal/modules/auth/domain"
+	filesDomain "github.com/inf-sys-secretary-methodologist/inf-sys-secretary-methodist/internal/modules/files/domain"
 	"github.com/inf-sys-secretary-methodologist/inf-sys-secretary-methodist/internal/modules/files/application/dto"
 	"github.com/inf-sys-secretary-methodologist/inf-sys-secretary-methodist/internal/modules/files/domain/entities"
 	"github.com/inf-sys-secretary-methodologist/inf-sys-secretary-methodist/internal/modules/files/domain/repositories"
@@ -115,9 +117,18 @@ func (uc *FileUseCase) UploadFile(ctx context.Context, reader io.Reader, input *
 }
 
 // GetFile получает информацию о файле по ID.
-func (uc *FileUseCase) GetFile(ctx context.Context, id int64) (*dto.FileResponse, error) {
+//
+// actorID/actorRole identify the caller for ownership gating
+// (AuthorizeFileAccess). Non-uploader callers без system_admin
+// override receive ErrFileAccessDenied — closes #290 ADR-1 IDOR.
+func (uc *FileUseCase) GetFile(ctx context.Context, id int64, actorID int64, actorRole authDomain.RoleType) (*dto.FileResponse, error) {
 	file, err := uc.fileRepo.GetByID(ctx, id)
 	if err != nil {
+		return nil, err
+	}
+
+	if err := filesDomain.AuthorizeFileAccess(actorID, actorRole, file, filesDomain.FileActionRead); err != nil {
+		uc.emitAccessDenied(ctx, actorID, file.ID, filesDomain.FileActionRead, "read")
 		return nil, err
 	}
 
@@ -125,9 +136,16 @@ func (uc *FileUseCase) GetFile(ctx context.Context, id int64) (*dto.FileResponse
 }
 
 // GetFileWithDownloadURL получает информацию о файле с URL для скачивания.
-func (uc *FileUseCase) GetFileWithDownloadURL(ctx context.Context, id int64, urlExpiration time.Duration) (*dto.FileResponse, error) {
+//
+// See GetFile docs for actorID/actorRole semantics.
+func (uc *FileUseCase) GetFileWithDownloadURL(ctx context.Context, id int64, urlExpiration time.Duration, actorID int64, actorRole authDomain.RoleType) (*dto.FileResponse, error) {
 	file, err := uc.fileRepo.GetByID(ctx, id)
 	if err != nil {
+		return nil, err
+	}
+
+	if err := filesDomain.AuthorizeFileAccess(actorID, actorRole, file, filesDomain.FileActionRead); err != nil {
+		uc.emitAccessDenied(ctx, actorID, file.ID, filesDomain.FileActionRead, "read_with_url")
 		return nil, err
 	}
 
@@ -144,9 +162,16 @@ func (uc *FileUseCase) GetFileWithDownloadURL(ctx context.Context, id int64, url
 }
 
 // DownloadFile возвращает данные для скачивания файла.
-func (uc *FileUseCase) DownloadFile(ctx context.Context, id int64) (*dto.DownloadResponse, error) {
+//
+// See GetFile docs for actorID/actorRole semantics.
+func (uc *FileUseCase) DownloadFile(ctx context.Context, id int64, actorID int64, actorRole authDomain.RoleType) (*dto.DownloadResponse, error) {
 	file, err := uc.fileRepo.GetByID(ctx, id)
 	if err != nil {
+		return nil, err
+	}
+
+	if err := filesDomain.AuthorizeFileAccess(actorID, actorRole, file, filesDomain.FileActionRead); err != nil {
+		uc.emitAccessDenied(ctx, actorID, file.ID, filesDomain.FileActionRead, "download")
 		return nil, err
 	}
 
@@ -165,9 +190,18 @@ func (uc *FileUseCase) DownloadFile(ctx context.Context, id int64) (*dto.Downloa
 }
 
 // AttachFile прикрепляет файл к документу, задаче или объявлению.
+//
+// input.UserID / input.UserRole identify the caller; only the uploader
+// may attach. No admin override (admins can read for forensics but
+// not impersonate the uploader). Closes #290 ADR-1 (Attach hijack).
 func (uc *FileUseCase) AttachFile(ctx context.Context, input *dto.AttachFileInput) error {
 	file, err := uc.fileRepo.GetByID(ctx, input.FileID)
 	if err != nil {
+		return err
+	}
+
+	if err := filesDomain.AuthorizeFileAccess(input.UserID, input.UserRole, file, filesDomain.FileActionAttach); err != nil {
+		uc.emitAccessDenied(ctx, input.UserID, file.ID, filesDomain.FileActionAttach, "attach")
 		return err
 	}
 
@@ -199,22 +233,42 @@ func (uc *FileUseCase) AttachFile(ctx context.Context, input *dto.AttachFileInpu
 			"document_id":     input.DocumentID,
 			"task_id":         input.TaskID,
 			"announcement_id": input.AnnouncementID,
+			"actor_user_id":   input.UserID,
 		})
 	}
 
 	return nil
 }
 
+// emitAccessDenied is a small helper for emitting standardised
+// access-denied audit events. Mirrors the v0.160.0 users denial
+// pattern: stable action names (`file_<action>_denied`) so analytics
+// can pivot consistently across modules.
+func (uc *FileUseCase) emitAccessDenied(ctx context.Context, actorID, fileID int64, action filesDomain.FileAction, reasonSuffix string) {
+	if uc.auditLogger == nil {
+		return
+	}
+	uc.auditLogger.LogAuditEvent(ctx, fmt.Sprintf("file_%s_denied", action), "file", map[string]interface{}{
+		"actor_user_id":  actorID,
+		"target_file_id": fileID,
+		"reason":         reasonSuffix,
+	})
+}
+
 // DeleteFile удаляет файл (мягкое удаление).
-func (uc *FileUseCase) DeleteFile(ctx context.Context, id int64, userID int64) error {
+//
+// Only the uploader may delete. The role parameter mirrors the other
+// usecases for symmetry but the rule rejects admin override на write
+// (closes #290 ADR-1).
+func (uc *FileUseCase) DeleteFile(ctx context.Context, id int64, actorID int64, actorRole authDomain.RoleType) error {
 	file, err := uc.fileRepo.GetByID(ctx, id)
 	if err != nil {
 		return err
 	}
 
-	// Проверяем права (только загрузивший может удалить)
-	if file.UploadedBy != userID {
-		return &PermissionError{Message: "нет прав на удаление файла"}
+	if err := filesDomain.AuthorizeFileAccess(actorID, actorRole, file, filesDomain.FileActionDelete); err != nil {
+		uc.emitAccessDenied(ctx, actorID, file.ID, filesDomain.FileActionDelete, "delete")
+		return err
 	}
 
 	err = uc.fileRepo.Delete(ctx, id)
@@ -226,7 +280,7 @@ func (uc *FileUseCase) DeleteFile(ctx context.Context, id int64, userID int64) e
 		uc.auditLogger.LogAuditEvent(ctx, "delete", "file", map[string]interface{}{
 			"file_id":       id,
 			"original_name": file.OriginalName,
-			"deleted_by":    userID,
+			"deleted_by":    actorID,
 		})
 	}
 

--- a/internal/modules/files/application/usecases/file_usecase.go
+++ b/internal/modules/files/application/usecases/file_usecase.go
@@ -11,8 +11,8 @@ import (
 	"time"
 
 	authDomain "github.com/inf-sys-secretary-methodologist/inf-sys-secretary-methodist/internal/modules/auth/domain"
-	filesDomain "github.com/inf-sys-secretary-methodologist/inf-sys-secretary-methodist/internal/modules/files/domain"
 	"github.com/inf-sys-secretary-methodologist/inf-sys-secretary-methodist/internal/modules/files/application/dto"
+	filesDomain "github.com/inf-sys-secretary-methodologist/inf-sys-secretary-methodist/internal/modules/files/domain"
 	"github.com/inf-sys-secretary-methodologist/inf-sys-secretary-methodist/internal/modules/files/domain/entities"
 	"github.com/inf-sys-secretary-methodologist/inf-sys-secretary-methodist/internal/modules/files/domain/repositories"
 	"github.com/inf-sys-secretary-methodologist/inf-sys-secretary-methodist/internal/shared/infrastructure/logging"
@@ -240,7 +240,7 @@ func (uc *FileUseCase) AttachFile(ctx context.Context, input *dto.AttachFileInpu
 	return nil
 }
 
-// emitAccessDenied is a small helper for emitting standardised
+// emitAccessDenied is a small helper for emitting standardized
 // access-denied audit events. Mirrors the v0.160.0 users denial
 // pattern: stable action names (`file_<action>_denied`) so analytics
 // can pivot consistently across modules.

--- a/internal/modules/files/application/usecases/file_usecase_test.go
+++ b/internal/modules/files/application/usecases/file_usecase_test.go
@@ -15,9 +15,18 @@ import (
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 
+	authDomain "github.com/inf-sys-secretary-methodologist/inf-sys-secretary-methodist/internal/modules/auth/domain"
 	"github.com/inf-sys-secretary-methodologist/inf-sys-secretary-methodist/internal/modules/files/application/dto"
+	filesDomain "github.com/inf-sys-secretary-methodologist/inf-sys-secretary-methodist/internal/modules/files/domain"
 	"github.com/inf-sys-secretary-methodologist/inf-sys-secretary-methodist/internal/modules/files/domain/entities"
 	"github.com/inf-sys-secretary-methodologist/inf-sys-secretary-methodist/internal/shared/infrastructure/storage"
+)
+
+// testActorMatching returns (actorID, role) that match an uploader.
+// Default fixture uploader is 1.
+const (
+	testUploaderID = int64(1)
+	testActorRole  = authDomain.RoleStudent
 )
 
 // --- Mock implementations ---
@@ -482,7 +491,7 @@ func TestFileUseCase_GetFile_Success(t *testing.T) {
 
 	mockFileRepo.On("GetByID", ctx, int64(1)).Return(expectedFile, nil).Once()
 
-	result, err := uc.GetFile(ctx, 1)
+	result, err := uc.GetFile(ctx, 1, testUploaderID, testActorRole)
 
 	require.NoError(t, err)
 	require.NotNil(t, result)
@@ -506,7 +515,7 @@ func TestFileUseCase_GetFile_NotFound(t *testing.T) {
 
 	mockFileRepo.On("GetByID", ctx, int64(999)).Return(nil, errors.New("not found")).Once()
 
-	result, err := uc.GetFile(ctx, 999)
+	result, err := uc.GetFile(ctx, 999, testUploaderID, testActorRole)
 
 	assert.Error(t, err)
 	assert.Nil(t, result)
@@ -536,7 +545,7 @@ func TestFileUseCase_GetFileWithDownloadURL_Success(t *testing.T) {
 	mockStorage.On("GetPresignedURL", ctx, "temp/1/test.pdf", 5*time.Minute).
 		Return("https://storage.example.com/presigned/test.pdf", nil).Once()
 
-	result, err := uc.GetFileWithDownloadURL(ctx, 1, 5*time.Minute)
+	result, err := uc.GetFileWithDownloadURL(ctx, 1, 5*time.Minute, testUploaderID, testActorRole)
 
 	require.NoError(t, err)
 	require.NotNil(t, result)
@@ -554,7 +563,7 @@ func TestFileUseCase_GetFileWithDownloadURL_FileNotFound(t *testing.T) {
 
 	mockFileRepo.On("GetByID", ctx, int64(1)).Return(nil, errors.New("not found")).Once()
 
-	result, err := uc.GetFileWithDownloadURL(ctx, 1, 5*time.Minute)
+	result, err := uc.GetFileWithDownloadURL(ctx, 1, 5*time.Minute, testUploaderID, testActorRole)
 
 	assert.Error(t, err)
 	assert.Nil(t, result)
@@ -570,13 +579,14 @@ func TestFileUseCase_GetFileWithDownloadURL_PresignError(t *testing.T) {
 	file := &entities.FileMetadata{
 		ID:         1,
 		StorageKey: "temp/1/test.pdf",
+		UploadedBy: testUploaderID,
 	}
 
 	mockFileRepo.On("GetByID", ctx, int64(1)).Return(file, nil).Once()
 	mockStorage.On("GetPresignedURL", ctx, "temp/1/test.pdf", 5*time.Minute).
 		Return("", errors.New("presign failed")).Once()
 
-	result, err := uc.GetFileWithDownloadURL(ctx, 1, 5*time.Minute)
+	result, err := uc.GetFileWithDownloadURL(ctx, 1, 5*time.Minute, testUploaderID, testActorRole)
 
 	assert.Error(t, err)
 	assert.Nil(t, result)
@@ -598,13 +608,14 @@ func TestFileUseCase_DownloadFile_Success(t *testing.T) {
 		StorageKey:   "temp/1/doc.pdf",
 		MimeType:     "application/pdf",
 		Size:         2048,
+		UploadedBy:   testUploaderID,
 	}
 
 	mockFileRepo.On("GetByID", ctx, int64(1)).Return(file, nil).Once()
 	mockStorage.On("GetPresignedURL", ctx, "temp/1/doc.pdf", time.Hour).
 		Return("https://example.com/presigned", nil).Once()
 
-	result, err := uc.DownloadFile(ctx, 1)
+	result, err := uc.DownloadFile(ctx, 1, testUploaderID, testActorRole)
 
 	require.NoError(t, err)
 	require.NotNil(t, result)
@@ -622,7 +633,7 @@ func TestFileUseCase_DownloadFile_FileNotFound(t *testing.T) {
 
 	mockFileRepo.On("GetByID", ctx, int64(1)).Return(nil, errors.New("not found")).Once()
 
-	result, err := uc.DownloadFile(ctx, 1)
+	result, err := uc.DownloadFile(ctx, 1, testUploaderID, testActorRole)
 
 	assert.Error(t, err)
 	assert.Nil(t, result)
@@ -638,13 +649,14 @@ func TestFileUseCase_DownloadFile_PresignError(t *testing.T) {
 	file := &entities.FileMetadata{
 		ID:         1,
 		StorageKey: "key",
+		UploadedBy: testUploaderID,
 	}
 
 	mockFileRepo.On("GetByID", ctx, int64(1)).Return(file, nil).Once()
 	mockStorage.On("GetPresignedURL", ctx, "key", time.Hour).
 		Return("", errors.New("s3 error")).Once()
 
-	result, err := uc.DownloadFile(ctx, 1)
+	result, err := uc.DownloadFile(ctx, 1, testUploaderID, testActorRole)
 
 	assert.Error(t, err)
 	assert.Nil(t, result)
@@ -674,6 +686,8 @@ func TestFileUseCase_AttachFile_ToDocument(t *testing.T) {
 	input := &dto.AttachFileInput{
 		FileID:     1,
 		DocumentID: &docID,
+		UserID:     1, // matches tempFile.UploadedBy
+		UserRole:   testActorRole,
 	}
 
 	err := uc.AttachFile(ctx, input)
@@ -852,7 +866,7 @@ func TestFileUseCase_DeleteFile_Success(t *testing.T) {
 	mockFileRepo.On("Delete", ctx, int64(1)).Return(nil).Once()
 	mockAudit.On("LogAuditEvent", ctx, "delete", "file", mock.Anything).Once()
 
-	err := uc.DeleteFile(ctx, 1, 1)
+	err := uc.DeleteFile(ctx, 1, 1, testActorRole)
 
 	require.NoError(t, err)
 	mockFileRepo.AssertExpectations(t)
@@ -872,11 +886,10 @@ func TestFileUseCase_DeleteFile_NoPermission(t *testing.T) {
 
 	mockFileRepo.On("GetByID", ctx, int64(1)).Return(file, nil).Once()
 
-	err := uc.DeleteFile(ctx, 1, 2)
+	err := uc.DeleteFile(ctx, 1, 2, testActorRole)
 
 	require.Error(t, err)
-	var permErr *PermissionError
-	assert.True(t, errors.As(err, &permErr))
+	assert.True(t, errors.Is(err, filesDomain.ErrFileAccessDenied))
 }
 
 func TestFileUseCase_DeleteFile_GetByIDError(t *testing.T) {
@@ -887,7 +900,7 @@ func TestFileUseCase_DeleteFile_GetByIDError(t *testing.T) {
 
 	mockFileRepo.On("GetByID", ctx, int64(1)).Return(nil, errors.New("not found")).Once()
 
-	err := uc.DeleteFile(ctx, 1, 1)
+	err := uc.DeleteFile(ctx, 1, 1, testActorRole)
 
 	require.Error(t, err)
 }
@@ -906,7 +919,7 @@ func TestFileUseCase_DeleteFile_RepoDeleteError(t *testing.T) {
 	mockFileRepo.On("GetByID", ctx, int64(1)).Return(file, nil).Once()
 	mockFileRepo.On("Delete", ctx, int64(1)).Return(errors.New("db error")).Once()
 
-	err := uc.DeleteFile(ctx, 1, 1)
+	err := uc.DeleteFile(ctx, 1, 1, testActorRole)
 
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "db error")
@@ -926,7 +939,7 @@ func TestFileUseCase_DeleteFile_WithoutAuditLogger(t *testing.T) {
 	mockFileRepo.On("GetByID", ctx, int64(1)).Return(file, nil).Once()
 	mockFileRepo.On("Delete", ctx, int64(1)).Return(nil).Once()
 
-	err := uc.DeleteFile(ctx, 1, 1)
+	err := uc.DeleteFile(ctx, 1, 1, testActorRole)
 
 	require.NoError(t, err)
 }
@@ -1393,4 +1406,120 @@ func TestPermissionError(t *testing.T) {
 	err := &PermissionError{Message: "тестовая ошибка доступа"}
 	assert.Equal(t, "тестовая ошибка доступа", err.Error())
 	assert.Implements(t, (*error)(nil), err)
+}
+
+// --- ADR-1 cross-user IDOR coverage (#290) ---
+
+func TestFileUseCase_GetFile_OtherUserDenied(t *testing.T) {
+	mockFileRepo := new(MockFileMetadataRepository)
+	mockAudit := new(MockAuditLogger)
+	uc := newTestFileUseCase(mockFileRepo, nil, nil, nil, mockAudit)
+	ctx := context.Background()
+
+	file := &entities.FileMetadata{ID: 1, UploadedBy: testUploaderID}
+	mockFileRepo.On("GetByID", ctx, int64(1)).Return(file, nil).Once()
+	mockAudit.On("LogAuditEvent", ctx, "file_read_denied", "file", mock.MatchedBy(func(f map[string]interface{}) bool {
+		return f["actor_user_id"] == int64(99) && f["target_file_id"] == int64(1) && f["reason"] == "read"
+	})).Once()
+
+	result, err := uc.GetFile(ctx, 1, 99, authDomain.RoleStudent)
+
+	assert.Nil(t, result)
+	assert.True(t, errors.Is(err, filesDomain.ErrFileAccessDenied))
+	mockAudit.AssertExpectations(t)
+}
+
+func TestFileUseCase_GetFile_SystemAdminAllowedOnOthersFile(t *testing.T) {
+	mockFileRepo := new(MockFileMetadataRepository)
+	uc := newTestFileUseCase(mockFileRepo, nil, nil, nil, nil)
+	ctx := context.Background()
+
+	file := &entities.FileMetadata{ID: 1, UploadedBy: testUploaderID, OriginalName: "x.pdf"}
+	mockFileRepo.On("GetByID", ctx, int64(1)).Return(file, nil).Once()
+
+	result, err := uc.GetFile(ctx, 1, 99, authDomain.RoleSystemAdmin)
+
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	assert.Equal(t, "x.pdf", result.OriginalName)
+}
+
+func TestFileUseCase_DownloadFile_OtherUserDenied(t *testing.T) {
+	mockFileRepo := new(MockFileMetadataRepository)
+	mockAudit := new(MockAuditLogger)
+	uc := newTestFileUseCase(mockFileRepo, nil, nil, nil, mockAudit)
+	ctx := context.Background()
+
+	file := &entities.FileMetadata{ID: 1, UploadedBy: testUploaderID, StorageKey: "k"}
+	mockFileRepo.On("GetByID", ctx, int64(1)).Return(file, nil).Once()
+	mockAudit.On("LogAuditEvent", ctx, "file_read_denied", "file", mock.Anything).Once()
+
+	result, err := uc.DownloadFile(ctx, 1, 99, authDomain.RoleStudent)
+
+	assert.Nil(t, result)
+	assert.True(t, errors.Is(err, filesDomain.ErrFileAccessDenied))
+	mockAudit.AssertExpectations(t)
+}
+
+func TestFileUseCase_AttachFile_OtherUserDenied(t *testing.T) {
+	mockFileRepo := new(MockFileMetadataRepository)
+	mockAudit := new(MockAuditLogger)
+	uc := newTestFileUseCase(mockFileRepo, nil, nil, nil, mockAudit)
+	ctx := context.Background()
+
+	file := &entities.FileMetadata{ID: 1, UploadedBy: testUploaderID, IsTemporary: true}
+	mockFileRepo.On("GetByID", ctx, int64(1)).Return(file, nil).Once()
+	mockAudit.On("LogAuditEvent", ctx, "file_attach_denied", "file", mock.Anything).Once()
+
+	docID := int64(50)
+	input := &dto.AttachFileInput{
+		FileID:     1,
+		DocumentID: &docID,
+		UserID:     99, // not the uploader
+		UserRole:   authDomain.RoleStudent,
+	}
+
+	err := uc.AttachFile(ctx, input)
+
+	assert.True(t, errors.Is(err, filesDomain.ErrFileAccessDenied))
+	mockAudit.AssertExpectations(t)
+}
+
+func TestFileUseCase_AttachFile_SystemAdminDeniedOnOthersFile(t *testing.T) {
+	// Admin override does NOT apply to write actions — only the uploader
+	// may attach.
+	mockFileRepo := new(MockFileMetadataRepository)
+	uc := newTestFileUseCase(mockFileRepo, nil, nil, nil, nil)
+	ctx := context.Background()
+
+	file := &entities.FileMetadata{ID: 1, UploadedBy: testUploaderID, IsTemporary: true}
+	mockFileRepo.On("GetByID", ctx, int64(1)).Return(file, nil).Once()
+
+	docID := int64(50)
+	input := &dto.AttachFileInput{
+		FileID:     1,
+		DocumentID: &docID,
+		UserID:     99,
+		UserRole:   authDomain.RoleSystemAdmin,
+	}
+
+	err := uc.AttachFile(ctx, input)
+
+	assert.True(t, errors.Is(err, filesDomain.ErrFileAccessDenied))
+}
+
+func TestFileUseCase_DeleteFile_OtherUserDenied(t *testing.T) {
+	mockFileRepo := new(MockFileMetadataRepository)
+	mockAudit := new(MockAuditLogger)
+	uc := newTestFileUseCase(mockFileRepo, nil, nil, nil, mockAudit)
+	ctx := context.Background()
+
+	file := &entities.FileMetadata{ID: 1, UploadedBy: testUploaderID}
+	mockFileRepo.On("GetByID", ctx, int64(1)).Return(file, nil).Once()
+	mockAudit.On("LogAuditEvent", ctx, "file_delete_denied", "file", mock.Anything).Once()
+
+	err := uc.DeleteFile(ctx, 1, 99, authDomain.RoleStudent)
+
+	assert.True(t, errors.Is(err, filesDomain.ErrFileAccessDenied))
+	mockAudit.AssertExpectations(t)
 }

--- a/internal/modules/files/domain/authz.go
+++ b/internal/modules/files/domain/authz.go
@@ -28,7 +28,7 @@ const (
 	FileActionDelete FileAction = "delete"
 )
 
-// ErrFileAccessDenied is returned when an actor is not authorised for
+// ErrFileAccessDenied is returned when an actor is not authorized for
 // the requested action against a file.
 //
 // Closes v1.0.0 batch 2 TIER 0 findings (#290 ADR-1 + ADR-2): files

--- a/internal/modules/files/domain/authz.go
+++ b/internal/modules/files/domain/authz.go
@@ -1,0 +1,56 @@
+// Package domain contains domain primitives for the files module.
+//
+// Authorization rules for file access live here as free functions so
+// they can be reused across usecases without coupling to repository
+// or middleware concerns.
+package domain
+
+import (
+	"errors"
+
+	authDomain "github.com/inf-sys-secretary-methodologist/inf-sys-secretary-methodist/internal/modules/auth/domain"
+	"github.com/inf-sys-secretary-methodologist/inf-sys-secretary-methodist/internal/modules/files/domain/entities"
+)
+
+// FileAction enumerates the actions that AuthorizeFileAccess gates.
+type FileAction string
+
+const (
+	// FileActionRead covers GET file metadata and GET download URL.
+	FileActionRead FileAction = "read"
+	// FileActionAttach covers attaching a temporary file to a document,
+	// task, or announcement (one-shot; permanent ownership transfer).
+	FileActionAttach FileAction = "attach"
+	// FileActionCreateVersion covers uploading a new version of an
+	// already-attached file.
+	FileActionCreateVersion FileAction = "create_version"
+	// FileActionDelete covers soft-deleting a file.
+	FileActionDelete FileAction = "delete"
+)
+
+// ErrFileAccessDenied is returned when an actor is not authorised for
+// the requested action against a file.
+//
+// Closes v1.0.0 batch 2 TIER 0 findings (#290 ADR-1 + ADR-2): files
+// usecases previously accepted only an `id int64` and never compared
+// against `FileMetadata.UploadedBy`, so any authenticated user could
+// read, download, attach, version, or delete any file via sequential
+// BIGSERIAL enumeration.
+var ErrFileAccessDenied = errors.New("file access denied")
+
+// AuthorizeFileAccess returns nil if `actor` is permitted to perform
+// `action` against `file`, ErrFileAccessDenied otherwise.
+//
+// STUB — replace with real rule in GREEN commit.
+func AuthorizeFileAccess(
+	actorID int64,
+	actorRole authDomain.RoleType,
+	file *entities.FileMetadata,
+	action FileAction,
+) error {
+	_ = actorID
+	_ = actorRole
+	_ = file
+	_ = action
+	return nil
+}

--- a/internal/modules/files/domain/authz.go
+++ b/internal/modules/files/domain/authz.go
@@ -41,16 +41,38 @@ var ErrFileAccessDenied = errors.New("file access denied")
 // AuthorizeFileAccess returns nil if `actor` is permitted to perform
 // `action` against `file`, ErrFileAccessDenied otherwise.
 //
-// STUB — replace with real rule in GREEN commit.
+// Rules:
+//
+//  1. Nil file is always denied (defensive — caller bug, fail closed).
+//  2. The uploader (actorID == file.UploadedBy) is allowed every action.
+//  3. For FileActionRead, system_admin is allowed on any file (broad
+//     read access for support/forensics). No other role overrides
+//     read — methodist/academic_secretary/teacher all fall through.
+//  4. For write actions (Attach / CreateVersion / Delete), NO role
+//     override exists. Only the uploader may mutate. Admins can read
+//     for inspection but cannot impersonate the uploader (attach под
+//     someone else's identity, push a malicious version, or remove
+//     someone else's audit-trail file).
+//  5. Unknown actions default-deny.
 func AuthorizeFileAccess(
 	actorID int64,
 	actorRole authDomain.RoleType,
 	file *entities.FileMetadata,
 	action FileAction,
 ) error {
-	_ = actorID
-	_ = actorRole
-	_ = file
-	_ = action
-	return nil
+	if file == nil {
+		return ErrFileAccessDenied
+	}
+	if file.UploadedBy == actorID {
+		switch action {
+		case FileActionRead, FileActionAttach, FileActionCreateVersion, FileActionDelete:
+			return nil
+		default:
+			return ErrFileAccessDenied
+		}
+	}
+	if action == FileActionRead && actorRole == authDomain.RoleSystemAdmin {
+		return nil
+	}
+	return ErrFileAccessDenied
 }

--- a/internal/modules/files/domain/authz_test.go
+++ b/internal/modules/files/domain/authz_test.go
@@ -1,0 +1,74 @@
+package domain_test
+
+import (
+	"errors"
+	"testing"
+
+	authDomain "github.com/inf-sys-secretary-methodologist/inf-sys-secretary-methodist/internal/modules/auth/domain"
+	"github.com/inf-sys-secretary-methodologist/inf-sys-secretary-methodist/internal/modules/files/domain"
+	"github.com/inf-sys-secretary-methodologist/inf-sys-secretary-methodist/internal/modules/files/domain/entities"
+)
+
+func TestAuthorizeFileAccess(t *testing.T) {
+	const uploaderID = int64(10)
+	const otherID = int64(99)
+
+	file := &entities.FileMetadata{ID: 1, UploadedBy: uploaderID}
+
+	cases := []struct {
+		name      string
+		actorID   int64
+		actorRole authDomain.RoleType
+		action    domain.FileAction
+		wantErr   bool
+	}{
+		{"uploader reads own file", uploaderID, authDomain.RoleStudent, domain.FileActionRead, false},
+		{"uploader attaches own file", uploaderID, authDomain.RoleStudent, domain.FileActionAttach, false},
+		{"uploader creates version of own file", uploaderID, authDomain.RoleStudent, domain.FileActionCreateVersion, false},
+		{"uploader deletes own file", uploaderID, authDomain.RoleStudent, domain.FileActionDelete, false},
+
+		{"other student reads — denied", otherID, authDomain.RoleStudent, domain.FileActionRead, true},
+		{"other student attaches — denied", otherID, authDomain.RoleStudent, domain.FileActionAttach, true},
+		{"other student creates version — denied", otherID, authDomain.RoleStudent, domain.FileActionCreateVersion, true},
+		{"other student deletes — denied", otherID, authDomain.RoleStudent, domain.FileActionDelete, true},
+
+		{"system_admin reads other's file — allowed", otherID, authDomain.RoleSystemAdmin, domain.FileActionRead, false},
+		{"system_admin attaches other's file — denied (no admin write override)", otherID, authDomain.RoleSystemAdmin, domain.FileActionAttach, true},
+		{"system_admin creates version в чужом файле — denied", otherID, authDomain.RoleSystemAdmin, domain.FileActionCreateVersion, true},
+		{"system_admin deletes other's file — denied", otherID, authDomain.RoleSystemAdmin, domain.FileActionDelete, true},
+
+		{"methodist reads other's file — denied (no role override for read)", otherID, authDomain.RoleMethodist, domain.FileActionRead, true},
+		{"academic_secretary reads other's file — denied", otherID, authDomain.RoleAcademicSecretary, domain.FileActionRead, true},
+		{"teacher reads other's file — denied", otherID, authDomain.RoleTeacher, domain.FileActionRead, true},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := domain.AuthorizeFileAccess(tc.actorID, tc.actorRole, file, tc.action)
+			if tc.wantErr {
+				if !errors.Is(err, domain.ErrFileAccessDenied) {
+					t.Errorf("AuthorizeFileAccess() = %v, want ErrFileAccessDenied", err)
+				}
+				return
+			}
+			if err != nil {
+				t.Errorf("AuthorizeFileAccess() = %v, want nil", err)
+			}
+		})
+	}
+}
+
+func TestAuthorizeFileAccess_NilFile(t *testing.T) {
+	err := domain.AuthorizeFileAccess(1, authDomain.RoleSystemAdmin, nil, domain.FileActionRead)
+	if !errors.Is(err, domain.ErrFileAccessDenied) {
+		t.Errorf("AuthorizeFileAccess(nil file) = %v, want ErrFileAccessDenied", err)
+	}
+}
+
+func TestAuthorizeFileAccess_UnknownAction(t *testing.T) {
+	file := &entities.FileMetadata{ID: 1, UploadedBy: 10}
+	err := domain.AuthorizeFileAccess(10, authDomain.RoleStudent, file, domain.FileAction("unknown"))
+	if !errors.Is(err, domain.ErrFileAccessDenied) {
+		t.Errorf("AuthorizeFileAccess(unknown action) = %v, want ErrFileAccessDenied (default-deny)", err)
+	}
+}

--- a/internal/modules/files/interfaces/http/handlers/file_handler.go
+++ b/internal/modules/files/interfaces/http/handlers/file_handler.go
@@ -9,11 +9,35 @@ import (
 
 	"github.com/gin-gonic/gin"
 
+	authDomain "github.com/inf-sys-secretary-methodologist/inf-sys-secretary-methodist/internal/modules/auth/domain"
 	"github.com/inf-sys-secretary-methodologist/inf-sys-secretary-methodist/internal/modules/files/application/dto"
 	"github.com/inf-sys-secretary-methodologist/inf-sys-secretary-methodist/internal/modules/files/application/usecases"
 	"github.com/inf-sys-secretary-methodologist/inf-sys-secretary-methodist/internal/shared/infrastructure/http/response"
 	"github.com/inf-sys-secretary-methodologist/inf-sys-secretary-methodist/internal/shared/infrastructure/validation"
 )
+
+// readActor extracts the authenticated actor (userID + role) from the
+// gin context. Returns ok=false if either is missing or wrong-typed,
+// so the caller can emit 401 once and bail out.
+func readActor(c *gin.Context) (int64, authDomain.RoleType, bool) {
+	uidVal, exists := c.Get("user_id")
+	if !exists {
+		return 0, "", false
+	}
+	uid, ok := uidVal.(int64)
+	if !ok {
+		return 0, "", false
+	}
+	roleVal, _ := c.Get("role")
+	role, _ := roleVal.(authDomain.RoleType)
+	if role == "" {
+		// Some middleware paths set role as a plain string.
+		if rs, ok := roleVal.(string); ok {
+			role = authDomain.RoleType(rs)
+		}
+	}
+	return uid, role, true
+}
 
 // FileHandler обрабатывает HTTP запросы для управления файлами.
 type FileHandler struct {
@@ -92,8 +116,15 @@ func (h *FileHandler) GetByID(c *gin.Context) {
 		return
 	}
 
+	actorID, actorRole, ok := readActor(c)
+	if !ok {
+		resp := response.Unauthorized("Требуется авторизация")
+		c.JSON(http.StatusUnauthorized, resp)
+		return
+	}
+
 	ctx := c.Request.Context()
-	result, err := h.fileUseCase.GetFile(ctx, id)
+	result, err := h.fileUseCase.GetFile(ctx, id, actorID, actorRole)
 	if err != nil {
 		httpErr := response.MapDomainError(err)
 		c.JSON(httpErr.Status, httpErr.Response)
@@ -112,8 +143,15 @@ func (h *FileHandler) Download(c *gin.Context) {
 		return
 	}
 
+	actorID, actorRole, ok := readActor(c)
+	if !ok {
+		resp := response.Unauthorized("Требуется авторизация")
+		c.JSON(http.StatusUnauthorized, resp)
+		return
+	}
+
 	ctx := c.Request.Context()
-	result, err := h.fileUseCase.DownloadFile(ctx, id)
+	result, err := h.fileUseCase.DownloadFile(ctx, id, actorID, actorRole)
 	if err != nil {
 		httpErr := response.MapDomainError(err)
 		c.JSON(httpErr.Status, httpErr.Response)
@@ -132,6 +170,13 @@ func (h *FileHandler) Attach(c *gin.Context) {
 		return
 	}
 
+	actorID, actorRole, ok := readActor(c)
+	if !ok {
+		resp := response.Unauthorized("Требуется авторизация")
+		c.JSON(http.StatusUnauthorized, resp)
+		return
+	}
+
 	var input dto.AttachFileInput
 	if err := c.ShouldBindJSON(&input); err != nil {
 		resp := response.BadRequest("Неверный формат запроса")
@@ -139,6 +184,8 @@ func (h *FileHandler) Attach(c *gin.Context) {
 		return
 	}
 	input.FileID = id
+	input.UserID = actorID
+	input.UserRole = actorRole
 
 	ctx := c.Request.Context()
 	if err := h.fileUseCase.AttachFile(ctx, &input); err != nil {
@@ -165,17 +212,15 @@ func (h *FileHandler) Delete(c *gin.Context) {
 		return
 	}
 
-	// Получаем user_id из контекста
-	userIDVal, exists := c.Get("user_id")
-	if !exists {
+	actorID, actorRole, ok := readActor(c)
+	if !ok {
 		resp := response.Unauthorized("Требуется авторизация")
 		c.JSON(http.StatusUnauthorized, resp)
 		return
 	}
-	userID, _ := userIDVal.(int64)
 
 	ctx := c.Request.Context()
-	if err := h.fileUseCase.DeleteFile(ctx, id, userID); err != nil {
+	if err := h.fileUseCase.DeleteFile(ctx, id, actorID, actorRole); err != nil {
 		var permErr *usecases.PermissionError
 		if errors.As(err, &permErr) {
 			resp := response.Forbidden(permErr.Message)

--- a/internal/modules/files/interfaces/http/handlers/file_handler_test.go
+++ b/internal/modules/files/interfaces/http/handlers/file_handler_test.go
@@ -14,8 +14,15 @@ func init() {
 	gin.SetMode(gin.TestMode)
 }
 
+// defaultFixtureUploader matches the UploadedBy value used by
+// entities.NewFileMetadata(..., 7) fixtures throughout the tests. The
+// shared router wires a stub authMW with this id so authenticated
+// handlers receive matching actor context.
+const defaultFixtureUploader = int64(7)
+
 func setupFileRouter(handler *FileHandler) *gin.Engine {
 	r := gin.New()
+	r.Use(authMW(defaultFixtureUploader))
 	r.POST("/files/upload", handler.Upload)
 	r.GET("/files/:id", handler.GetByID)
 	r.GET("/files/:id/download", handler.Download)

--- a/internal/modules/files/interfaces/http/handlers/file_handler_usecase_test.go
+++ b/internal/modules/files/interfaces/http/handlers/file_handler_usecase_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	authDomain "github.com/inf-sys-secretary-methodologist/inf-sys-secretary-methodist/internal/modules/auth/domain"
 	"github.com/inf-sys-secretary-methodologist/inf-sys-secretary-methodist/internal/modules/files/application/usecases"
 	"github.com/inf-sys-secretary-methodologist/inf-sys-secretary-methodist/internal/modules/files/domain/entities"
 	"github.com/inf-sys-secretary-methodologist/inf-sys-secretary-methodist/internal/modules/files/domain/repositories"
@@ -125,10 +126,19 @@ func (r *fakeFileMetaRepo) CleanupExpired(_ context.Context) (int64, error) {
 // satisfy compile-time interface check
 var _ repositories.FileMetadataRepository = (*fakeFileMetaRepo)(nil)
 
-// authMW устанавливает user_id в Gin context, как production middleware.
-func authMW(userID int64) gin.HandlerFunc {
+// authMW устанавливает user_id + role в Gin context, как production middleware.
+//
+// role mirrors auth/middleware behaviour — defaults to student if caller
+// omits it (most tests want the uploader case where role doesn't matter
+// for the rule, only id-match does).
+func authMW(userID int64, roles ...authDomain.RoleType) gin.HandlerFunc {
+	role := authDomain.RoleStudent
+	if len(roles) > 0 {
+		role = roles[0]
+	}
 	return func(c *gin.Context) {
 		c.Set("user_id", userID)
+		c.Set("role", role)
 		c.Next()
 	}
 }

--- a/internal/modules/files/interfaces/http/handlers/file_handler_usecase_test.go
+++ b/internal/modules/files/interfaces/http/handlers/file_handler_usecase_test.go
@@ -128,7 +128,7 @@ var _ repositories.FileMetadataRepository = (*fakeFileMetaRepo)(nil)
 
 // authMW устанавливает user_id + role в Gin context, как production middleware.
 //
-// role mirrors auth/middleware behaviour — defaults to student if caller
+// role mirrors auth/middleware behavior — defaults to student if caller
 // omits it (most tests want the uploader case where role doesn't matter
 // for the rule, only id-match does).
 func authMW(userID int64, roles ...authDomain.RoleType) gin.HandlerFunc {

--- a/internal/shared/infrastructure/http/response/error_mapper.go
+++ b/internal/shared/infrastructure/http/response/error_mapper.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"net/http"
 
+	filesDomain "github.com/inf-sys-secretary-methodologist/inf-sys-secretary-methodist/internal/modules/files/domain"
 	usersDomain "github.com/inf-sys-secretary-methodologist/inf-sys-secretary-methodist/internal/modules/users/domain"
 	domainErrors "github.com/inf-sys-secretary-methodologist/inf-sys-secretary-methodist/internal/shared/domain/errors"
 )
@@ -105,6 +106,15 @@ func MapDomainError(err error) HTTPError {
 		return HTTPError{
 			Status:   http.StatusConflict,
 			Response: ErrorResponse("LAST_ADMIN_PROTECTED", "Нельзя удалить или заблокировать последнего администратора"),
+		}
+
+	// files module sentinel — closes #290 ADR-1+ADR-2: cross-user
+	// IDOR / Attach hijack / CreateVersion hijack all surface as
+	// ErrFileAccessDenied and must map to 403 (not 500).
+	case errors.Is(err, filesDomain.ErrFileAccessDenied):
+		return HTTPError{
+			Status:   http.StatusForbidden,
+			Response: ErrorResponse("FILE_ACCESS_DENIED", "Доступ к файлу запрещён"),
 		}
 	}
 


### PR DESCRIPTION
## Summary

**Part 1 of 3** split per user direction (\"разбей на более маленькие PR\"). PR Size policy 1000 LOC hard-fail respected.

Closes batch 2 v1.0.0 audit #3 (files = worst module / REJECT verdict) part 1: foundation + ADR-1 core (single-target IDOR — GetFile / Download / Attach / Delete).

## Sequencing

- **THIS PR (A)**: Foundation + ADR-1 single-target endpoints (~632 LOC)
- **PR-B (next)**: ADR-2 CreateVersion + ADR-3 dead validator + ADR-5 admin gate (~480 LOC)
- **PR-C (last)**: FIX-CYCLE absorbs (5 group-list endpoints + validator narrowing) + v0.161.0 release commit (~630 LOC)

Each ≤700 LOC, all under the 1000-line policy. Each PR depends на previous.

## Scope in this PR

- **Domain**: New free fn `AuthorizeFileAccess(actor, file, action) error` + `var ErrFileAccessDenied` sentinel + `FileAction` typed enum (read/attach/create_version/delete). System_admin читает override; uploader-only writes.
- **TDD pair (clean RED→GREEN)**: 12-case table-driven test for AuthorizeFileAccess; commit RED first (stub returns nil), GREEN replaces stub.
- **ADR-1 cascade single-target**: `GetFile` / `GetFileWithDownloadURL` / `DownloadFile` / `AttachFile` / `DeleteFile` signatures gain (actorID, role); each calls AuthorizeFileAccess + emits `file_<action>_denied` audit on deny. Handler-level `readActor` helper. `ErrFileAccessDenied` mapped к 403 в error_mapper.
- **Plan doc**: `docs/plans/2026-05-23-v0161-files-security.md` (full plan — ADR-2/3/5 land в PR-B, FIX-CYCLE work в PR-C).

## NOT in this PR (will land in B + C)

- ADR-2 CreateVersion ownership / DeleteVersion / DownloadVersion gates → PR-B
- ADR-3 dead validator wire-in → PR-B
- ADR-5 admin gate /cleanup → PR-B
- 5 group-list endpoints (List / GetByDocument / GetByTask / GetByAnnouncement / GetVersions) — round-1 reviewer T0 → PR-C
- Validator hardening rollback (round-2 reviewer T0-A) → PR-C
- Version bump 0.161.0 + tag — last PR (C)

Partial security closure. Production stays on v0.160.0 until PR-C merges. Этим маневром sub-targets stay coherent.

## Test plan

- [x] go test ./internal/modules/files/... → ok
- [x] go test ./internal/shared/infrastructure/http/response/... → ok
- [x] golangci-lint run on affected packages → 0 issues
- [x] LOC <1000 (632 actual)

Refs #290