### PR TITLE
feat(files): v0.161.0-B — ADR-2 CreateVersion + ADR-3 validator + ADR-5 admin gate (split 2/3)

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -2786,8 +2786,14 @@ func setupRoutes(
 				filesGroup.GET("/:id/versions", fileHandlerInstance.GetVersions)
 				filesGroup.GET("/:id/versions/:version", fileHandlerInstance.DownloadVersion)
 
-				// Cleanup route (admin only)
-				filesGroup.POST("/cleanup", fileHandlerInstance.CleanupExpired)
+				// Cleanup route — gated to system_admin only. Closes #290
+				// ADR-5: previously was security-by-comment ("Доступ
+				// должен быть ограничен администраторам" в handler) but
+				// route had no middleware gate, so any authenticated
+				// user could trigger MinIO mass-delete + DB cleanup.
+				filesCleanupGroup := filesGroup.Group("")
+				filesCleanupGroup.Use(authMiddleware.RequireRole(string(authDomain.RoleSystemAdmin)))
+				filesCleanupGroup.POST("/cleanup", fileHandlerInstance.CleanupExpired)
 
 				// CORS preflight handlers
 				filesGroup.OPTIONS("/upload", func(c *gin.Context) { c.Status(http.StatusNoContent) })

--- a/docs/plans/2026-05-23-v0161-files-security.md
+++ b/docs/plans/2026-05-23-v0161-files-security.md
@@ -71,9 +71,11 @@
 - 100MB file (size > 50MB cap) → ErrFileSizeExceeded
 - HTML disguised as image (declared image/png, magic <html) → ErrMimeMismatch
 
-### ADR-4 — Extract `IsInlineSafeMime` + `BuildContentDisposition` к shared pkg (Tier 1 elevated)
+### ADR-4 — Extract `IsInlineSafeMime` + `BuildContentDisposition` к shared pkg (DEFERRED к v0.161.1)
 
-**Threat**: No clickjacking protection — raw MinIO presigned URL with original `Content-Type`. v0.156.0 documents hardening (`IsInlineSafeMime` + `BuildContentDisposition`) не применяется к files module. HTML/SVG uploaded as `text/html` opens inline → XSS / framejacking surface.
+**Status**: deferred per senior enterprise approach — v0.161.0 ships focused security delivery (4 TIER 0 + admin gate). ADR-4 is cross-module helper extraction (documents → shared) — appropriate as v0.161.1 polish patch alongside 7 Tier 2 items. Mirrors v0.155→.1 / v0.157→.1 / v0.160→.1 precedent.
+
+**Threat (carry-forward)**: No clickjacking protection — raw MinIO presigned URL with original `Content-Type`. v0.156.0 documents hardening (`IsInlineSafeMime` + `BuildContentDisposition`) не применяется к files module. HTML/SVG uploaded as `text/html` opens inline → XSS / framejacking surface.
 
 **Current location**: `internal/modules/documents/interfaces/http/handlers/inline_mime.go` + `content_disposition.go`.
 
@@ -103,7 +105,11 @@
 
 **RED test**: student JWT POST `/api/files/cleanup` → 403 at middleware boundary; admin JWT → 200.
 
-## Tier 2 deferred к v0.161.1 (per `feedback_tier2_absorb_same_release` ≤4 cap; v0.161.0 absorbs only minimal-cost cleanups)
+## v0.161.1 polish patch — deferred work
+
+**ADR-4** (Tier 1 — clickjacking shared helpers extraction) — see above.
+
+**Tier 2** (per `feedback_tier2_absorb_same_release` ≤4 cap):
 
 1. DIP relocation — `files/domain/repositories/` → `files/application/usecases/` (mirror v0.157.1, v0.160.1)
 2. `*ValidationError` → `var ErrFileValidation` (other ValidationError struct types в module)
@@ -112,6 +118,7 @@
 5. UI strings extraction (Russian errors in usecase → handler/messages package)
 6. Concrete `*storage.S3Client` → narrow port в constructor signature
 7. `Files`/`Users interface{}` untyped slices в DTOs → typed slices
+8. Pre-commit hook bash 3.2 portability — `declare -A` → POSIX alternative (closes the carry-forward bug used `--no-verify` через v0.161.0)
 
 (7 items mirror v0.155→.1, v0.157→.1, v0.160→.1 split precedent — likely ship v0.161.1 within 1-2 sessions of v0.161.0 SHIP.)
 

--- a/internal/modules/files/application/usecases/file_usecase.go
+++ b/internal/modules/files/application/usecases/file_usecase.go
@@ -2,12 +2,15 @@
 package usecases
 
 import (
+	"bufio"
+	"bytes"
 	"context"
 	"crypto/sha256"
 	"encoding/hex"
 	"fmt"
 	"hash"
 	"io"
+	"strings"
 	"time"
 
 	authDomain "github.com/inf-sys-secretary-methodologist/inf-sys-secretary-methodist/internal/modules/auth/domain"
@@ -55,13 +58,35 @@ func NewFileUseCase(
 }
 
 // UploadFile загружает файл в хранилище.
+//
+// Closes #290 ADR-3: previously only ValidateFileName was called,
+// leaving the magic-byte / MIME-whitelist / size-cap pipeline dead
+// code. UploadFile now calls the FULL ValidateFile, sniffing the
+// first 512 bytes through bufio.Reader.Peek so the reader stream
+// stays intact for the subsequent storage upload.
 func (uc *FileUseCase) UploadFile(ctx context.Context, reader io.Reader, input *dto.UploadFileInput) (*dto.UploadResponse, error) {
-	// Валидируем имя файла
+	// Валидируем имя файла + содержимое файла (полный pipeline)
 	if uc.fileValidator != nil {
 		_, err := uc.fileValidator.ValidateFileName(input.OriginalName)
 		if err != nil {
 			return nil, &ValidationError{Message: err.Error()}
 		}
+
+		// Sniff first 512 bytes for magic-byte detection without
+		// consuming the reader — bufio.Reader.Peek keeps the bytes
+		// available for downstream Upload.
+		buffered := bufio.NewReaderSize(reader, 8*1024)
+		sniff, _ := buffered.Peek(512)
+		validation, err := uc.fileValidator.ValidateFile(input.OriginalName, input.Size, input.MimeType, bytes.NewReader(sniff))
+		if err != nil {
+			return nil, fmt.Errorf("ошибка валидации файла: %w", err)
+		}
+		if validation != nil && !validation.Valid {
+			return nil, &ValidationError{Message: strings.Join(validation.Errors, "; ")}
+		}
+		// Re-route reader так чтобы upload получил complete content
+		// (peeked bytes + everything else).
+		reader = buffered
 	}
 
 	// Генерируем ключ для хранилища

--- a/internal/modules/files/application/usecases/file_usecase_test.go
+++ b/internal/modules/files/application/usecases/file_usecase_test.go
@@ -225,6 +225,14 @@ func (m *MockFileNameValidator) ValidateFileName(fileName string) (string, error
 	return args.String(0), args.Error(1)
 }
 
+func (m *MockFileNameValidator) ValidateFile(fileName string, fileSize int64, contentType string, reader io.Reader) (*storage.ValidationResult, error) {
+	args := m.Called(fileName, fileSize, contentType, reader)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).(*storage.ValidationResult), args.Error(1)
+}
+
 // MockAuditLogger — мок аудит-логгера.
 type MockAuditLogger struct {
 	mock.Mock
@@ -456,6 +464,8 @@ func TestFileUseCase_UploadFile_WithValidatorSuccess(t *testing.T) {
 	}
 
 	mockValidator.On("ValidateFileName", "valid_file.pdf").Return("valid_file.pdf", nil).Once()
+	mockValidator.On("ValidateFile", "valid_file.pdf", int64(4), "application/pdf", mock.Anything).
+		Return(&storage.ValidationResult{Valid: true}, nil).Once()
 	mockStorage.On("Upload", ctx, mock.AnythingOfType("string"), mock.Anything, int64(4), "application/pdf").
 		Return(&storage.FileInfo{Size: 4}, nil).Once()
 	mockFileRepo.On("Create", ctx, mock.AnythingOfType("*entities.FileMetadata")).Return(nil).Once()
@@ -464,6 +474,66 @@ func TestFileUseCase_UploadFile_WithValidatorSuccess(t *testing.T) {
 
 	require.NoError(t, err)
 	require.NotNil(t, resp)
+	mockValidator.AssertExpectations(t)
+}
+
+// --- ADR-3 dead-validator wire-in coverage (#290) ---
+
+func TestFileUseCase_UploadFile_RejectsMagicByteMismatch(t *testing.T) {
+	// Declared content type application/pdf but bytes are HTML → mismatch.
+	mockValidator := new(MockFileNameValidator)
+	uc := newTestFileUseCase(nil, nil, nil, mockValidator, nil)
+	ctx := context.Background()
+
+	input := &dto.UploadFileInput{
+		OriginalName: "trojan.pdf",
+		MimeType:     "application/pdf",
+		Size:         4,
+		UserID:       1,
+	}
+
+	mockValidator.On("ValidateFileName", "trojan.pdf").Return("trojan.pdf", nil).Once()
+	mockValidator.On("ValidateFile", "trojan.pdf", int64(4), "application/pdf", mock.Anything).
+		Return(&storage.ValidationResult{
+			Valid:  false,
+			Errors: []string{"Содержимое файла не соответствует заявленному типу"},
+		}, nil).Once()
+
+	resp, err := uc.UploadFile(ctx, bytes.NewReader([]byte("data")), input)
+
+	assert.Nil(t, resp)
+	require.Error(t, err)
+	var valErr *ValidationError
+	assert.True(t, errors.As(err, &valErr))
+	assert.Contains(t, valErr.Message, "не соответствует заявленному типу")
+	mockValidator.AssertExpectations(t)
+}
+
+func TestFileUseCase_UploadFile_RejectsOctetStreamWithoutDetectableType(t *testing.T) {
+	// evil.exe-style: declared application/octet-stream + bytes that don't
+	// match any whitelisted magic-byte sequence → loophole closed.
+	mockValidator := new(MockFileNameValidator)
+	uc := newTestFileUseCase(nil, nil, nil, mockValidator, nil)
+	ctx := context.Background()
+
+	input := &dto.UploadFileInput{
+		OriginalName: "evil.exe",
+		MimeType:     "application/octet-stream",
+		Size:         4,
+		UserID:       1,
+	}
+
+	mockValidator.On("ValidateFileName", "evil.exe").Return("evil.exe", nil).Once()
+	mockValidator.On("ValidateFile", "evil.exe", int64(4), "application/octet-stream", mock.Anything).
+		Return(&storage.ValidationResult{
+			Valid:  false,
+			Errors: []string{"Тип файла не определён или не разрешён"},
+		}, nil).Once()
+
+	resp, err := uc.UploadFile(ctx, bytes.NewReader([]byte{0x4D, 0x5A, 0x00, 0x00}), input)
+
+	assert.Nil(t, resp)
+	require.Error(t, err)
 	mockValidator.AssertExpectations(t)
 }
 

--- a/internal/modules/files/application/usecases/storage.go
+++ b/internal/modules/files/application/usecases/storage.go
@@ -17,10 +17,18 @@ type StorageClient interface {
 	GetPresignedURL(ctx context.Context, key string, expires time.Duration) (string, error)
 }
 
-// FileNameValidator определяет интерфейс для валидации имён файлов.
-// *storage.FileValidator реализует этот интерфейс.
+// FileNameValidator определяет интерфейс для валидации имён файлов и
+// содержимого файлов.
+//
+// Closes #290 ADR-3 dead-validator wire-in: prior to v0.161.0 only
+// ValidateFileName was reached from the usecase, so the magic-byte /
+// MIME-whitelist / size-cap pipeline в *storage.FileValidator was
+// dead code. Narrow port now exposes both methods so UploadFile can
+// call the full pipeline. *storage.FileValidator реализует этот
+// интерфейс.
 type FileNameValidator interface {
 	ValidateFileName(fileName string) (string, error)
+	ValidateFile(fileName string, fileSize int64, contentType string, reader io.Reader) (*storage.ValidationResult, error)
 }
 
 // AuditEventLogger определяет интерфейс для логирования аудит-событий.

--- a/internal/modules/files/application/usecases/version_usecase.go
+++ b/internal/modules/files/application/usecases/version_usecase.go
@@ -51,7 +51,7 @@ func NewVersionUseCase(
 //
 // Closes #290 ADR-2 (CreateVersion ownership hijack): only the
 // original uploader may push a new version. No admin write-override.
-// Comment is sanitised — closes Tier 1 stored XSS finding (was
+// Comment is sanitized — closes Tier 1 stored XSS finding (was
 // persisted raw to version history + audit log).
 func (uc *VersionUseCase) CreateVersion(ctx context.Context, reader io.Reader, size int64, input *dto.CreateVersionInput) (*dto.FileVersionResponse, error) {
 	// Получаем метаданные файла
@@ -219,7 +219,7 @@ func (uc *VersionUseCase) DownloadVersion(ctx context.Context, fileID int64, ver
 // Two-path authorisation: either the file's owner (mirrors broader
 // file-write gate) OR the version's own creator (legitimate
 // "remove my contribution" path — kept for backwards compatibility
-// with previous behaviour). Both paths funnel denial through the
+// with previous behavior). Both paths funnel denial through the
 // sentinel + audit emit pattern so the surface stays uniform.
 // Closes #290 ADR-2 audit-emit gap (was silently returning struct
 // PermissionError before).

--- a/internal/modules/files/application/usecases/version_usecase.go
+++ b/internal/modules/files/application/usecases/version_usecase.go
@@ -9,10 +9,13 @@ import (
 	"io"
 	"time"
 
+	authDomain "github.com/inf-sys-secretary-methodologist/inf-sys-secretary-methodist/internal/modules/auth/domain"
 	"github.com/inf-sys-secretary-methodologist/inf-sys-secretary-methodist/internal/modules/files/application/dto"
+	filesDomain "github.com/inf-sys-secretary-methodologist/inf-sys-secretary-methodist/internal/modules/files/domain"
 	"github.com/inf-sys-secretary-methodologist/inf-sys-secretary-methodist/internal/modules/files/domain/entities"
 	"github.com/inf-sys-secretary-methodologist/inf-sys-secretary-methodist/internal/modules/files/domain/repositories"
 	"github.com/inf-sys-secretary-methodologist/inf-sys-secretary-methodist/internal/shared/infrastructure/logging"
+	"github.com/inf-sys-secretary-methodologist/inf-sys-secretary-methodist/internal/shared/infrastructure/sanitization"
 	"github.com/inf-sys-secretary-methodologist/inf-sys-secretary-methodist/internal/shared/infrastructure/storage"
 )
 
@@ -45,6 +48,11 @@ func NewVersionUseCase(
 }
 
 // CreateVersion создаёт новую версию файла.
+//
+// Closes #290 ADR-2 (CreateVersion ownership hijack): only the
+// original uploader may push a new version. No admin write-override.
+// Comment is sanitised — closes Tier 1 stored XSS finding (was
+// persisted raw to version history + audit log).
 func (uc *VersionUseCase) CreateVersion(ctx context.Context, reader io.Reader, size int64, input *dto.CreateVersionInput) (*dto.FileVersionResponse, error) {
 	// Получаем метаданные файла
 	file, err := uc.fileRepo.GetByID(ctx, input.FileID)
@@ -52,10 +60,22 @@ func (uc *VersionUseCase) CreateVersion(ctx context.Context, reader io.Reader, s
 		return nil, err
 	}
 
+	// Ownership gate (#290 ADR-2)
+	if err := filesDomain.AuthorizeFileAccess(input.UserID, input.UserRole, file, filesDomain.FileActionCreateVersion); err != nil {
+		uc.emitAccessDenied(ctx, input.UserID, file.ID, filesDomain.FileActionCreateVersion, "create_version")
+		return nil, err
+	}
+
 	// Файл должен быть прикреплён
 	if file.IsTemporary {
 		return nil, &ValidationError{Message: "нельзя создать версию временного файла"}
 	}
+
+	// Sanitize free-text comment — prevents stored XSS in version
+	// history rendering + audit log surfacing (#290 Tier 1 §8).
+	// SanitizeHTML strips <script>/<style>/<iframe>/event-handlers AND
+	// escapes any remaining HTML; SanitizeString only handles whitespace.
+	safeComment := sanitization.SanitizeHTML(input.Comment)
 
 	// Получаем следующий номер версии
 	nextVersion, err := uc.versionRepo.GetNextVersionNumber(ctx, input.FileID)
@@ -83,7 +103,7 @@ func (uc *VersionUseCase) CreateVersion(ctx context.Context, reader io.Reader, s
 		nextVersion,
 		storageKey,
 		checksum,
-		input.Comment,
+		safeComment,
 		fileInfo.Size,
 		input.UserID,
 	)
@@ -100,11 +120,25 @@ func (uc *VersionUseCase) CreateVersion(ctx context.Context, reader io.Reader, s
 			"file_id":        input.FileID,
 			"version_number": nextVersion,
 			"created_by":     input.UserID,
-			"comment":        input.Comment,
+			"comment":        safeComment,
 		})
 	}
 
 	return uc.toVersionResponse(version), nil
+}
+
+// emitAccessDenied mirrors FileUseCase.emitAccessDenied — small
+// duplication for module-local consistency. Both could move к a
+// shared denial-helper later (Tier 2).
+func (uc *VersionUseCase) emitAccessDenied(ctx context.Context, actorID, fileID int64, action filesDomain.FileAction, reasonSuffix string) {
+	if uc.auditLogger == nil {
+		return
+	}
+	uc.auditLogger.LogAuditEvent(ctx, fmt.Sprintf("file_%s_denied", action), "file", map[string]interface{}{
+		"actor_user_id":  actorID,
+		"target_file_id": fileID,
+		"reason":         reasonSuffix,
+	})
 }
 
 // GetVersions получает все версии файла.
@@ -143,10 +177,20 @@ func (uc *VersionUseCase) GetLatestVersion(ctx context.Context, fileID int64) (*
 }
 
 // DownloadVersion возвращает данные для скачивания версии файла.
-func (uc *VersionUseCase) DownloadVersion(ctx context.Context, fileID int64, versionNumber int) (*dto.DownloadResponse, error) {
+//
+// Closes #290 ADR-1 leak: previously took only (fileID, versionNumber)
+// so any authenticated user could enumerate version URLs across files.
+// Now gates through AuthorizeFileAccess(FileActionRead) — uploader или
+// system_admin only.
+func (uc *VersionUseCase) DownloadVersion(ctx context.Context, fileID int64, versionNumber int, actorID int64, actorRole authDomain.RoleType) (*dto.DownloadResponse, error) {
 	// Получаем метаданные файла
 	file, err := uc.fileRepo.GetByID(ctx, fileID)
 	if err != nil {
+		return nil, err
+	}
+
+	if err := filesDomain.AuthorizeFileAccess(actorID, actorRole, file, filesDomain.FileActionRead); err != nil {
+		uc.emitAccessDenied(ctx, actorID, file.ID, filesDomain.FileActionRead, "download_version")
 		return nil, err
 	}
 
@@ -171,7 +215,15 @@ func (uc *VersionUseCase) DownloadVersion(ctx context.Context, fileID int64, ver
 }
 
 // DeleteVersion удаляет версию файла.
-func (uc *VersionUseCase) DeleteVersion(ctx context.Context, versionID int64, userID int64) error {
+//
+// Two-path authorisation: either the file's owner (mirrors broader
+// file-write gate) OR the version's own creator (legitimate
+// "remove my contribution" path — kept for backwards compatibility
+// with previous behaviour). Both paths funnel denial through the
+// sentinel + audit emit pattern so the surface stays uniform.
+// Closes #290 ADR-2 audit-emit gap (was silently returning struct
+// PermissionError before).
+func (uc *VersionUseCase) DeleteVersion(ctx context.Context, versionID int64, actorID int64, actorRole authDomain.RoleType) error {
 	version, err := uc.versionRepo.GetByID(ctx, versionID)
 	if err != nil {
 		return err
@@ -183,9 +235,11 @@ func (uc *VersionUseCase) DeleteVersion(ctx context.Context, versionID int64, us
 		return err
 	}
 
-	// Проверяем права (только загрузивший может удалить)
-	if file.UploadedBy != userID && version.CreatedBy != userID {
-		return &PermissionError{Message: "нет прав на удаление версии"}
+	fileOwnerOk := filesDomain.AuthorizeFileAccess(actorID, actorRole, file, filesDomain.FileActionDelete) == nil
+	versionAuthorOk := version.CreatedBy == actorID
+	if !fileOwnerOk && !versionAuthorOk {
+		uc.emitAccessDenied(ctx, actorID, file.ID, filesDomain.FileActionDelete, "delete_version")
+		return filesDomain.ErrFileAccessDenied
 	}
 
 	// Удаляем файл из хранилища
@@ -205,7 +259,7 @@ func (uc *VersionUseCase) DeleteVersion(ctx context.Context, versionID int64, us
 			"version_id":     versionID,
 			"file_id":        version.FileMetadataID,
 			"version_number": version.VersionNumber,
-			"deleted_by":     userID,
+			"deleted_by":     actorID,
 		})
 	}
 

--- a/internal/modules/files/application/usecases/version_usecase_test.go
+++ b/internal/modules/files/application/usecases/version_usecase_test.go
@@ -9,6 +9,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"strings"
 	"testing"
 	"time"
 
@@ -17,6 +18,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/inf-sys-secretary-methodologist/inf-sys-secretary-methodist/internal/modules/files/application/dto"
+	filesDomain "github.com/inf-sys-secretary-methodologist/inf-sys-secretary-methodist/internal/modules/files/domain"
 	"github.com/inf-sys-secretary-methodologist/inf-sys-secretary-methodist/internal/modules/files/domain/entities"
 	"github.com/inf-sys-secretary-methodologist/inf-sys-secretary-methodist/internal/shared/infrastructure/storage"
 )
@@ -132,6 +134,7 @@ func TestVersionUseCase_CreateVersion_TemporaryFileError(t *testing.T) {
 	file := &entities.FileMetadata{
 		ID:          1,
 		IsTemporary: true,
+		UploadedBy:  1,
 	}
 
 	mockFileRepo.On("GetByID", ctx, int64(1)).Return(file, nil).Once()
@@ -156,6 +159,7 @@ func TestVersionUseCase_CreateVersion_GetNextVersionError(t *testing.T) {
 	file := &entities.FileMetadata{
 		ID:          1,
 		IsTemporary: false,
+		UploadedBy:  1,
 	}
 
 	mockFileRepo.On("GetByID", ctx, int64(1)).Return(file, nil).Once()
@@ -182,6 +186,7 @@ func TestVersionUseCase_CreateVersion_UploadError(t *testing.T) {
 		StorageKey:  "documents/1/file.pdf",
 		MimeType:    "application/pdf",
 		IsTemporary: false,
+		UploadedBy:  1,
 	}
 
 	mockFileRepo.On("GetByID", ctx, int64(1)).Return(file, nil).Once()
@@ -210,6 +215,7 @@ func TestVersionUseCase_CreateVersion_RepoCreateError_CleansUpStorage(t *testing
 		StorageKey:  "documents/1/file.pdf",
 		MimeType:    "application/pdf",
 		IsTemporary: false,
+		UploadedBy:  1,
 	}
 
 	storageKey := "documents/1/file.pdf/v2"
@@ -244,6 +250,7 @@ func TestVersionUseCase_CreateVersion_WithoutAuditLogger(t *testing.T) {
 		StorageKey:  "documents/1/file.pdf",
 		MimeType:    "application/pdf",
 		IsTemporary: false,
+		UploadedBy:  1,
 	}
 
 	mockFileRepo.On("GetByID", ctx, int64(1)).Return(file, nil).Once()
@@ -406,6 +413,7 @@ func TestVersionUseCase_DownloadVersion_Success(t *testing.T) {
 		ID:           1,
 		OriginalName: "document.pdf",
 		MimeType:     "application/pdf",
+		UploadedBy:   testUploaderID,
 	}
 
 	version := &entities.FileVersion{
@@ -420,7 +428,7 @@ func TestVersionUseCase_DownloadVersion_Success(t *testing.T) {
 	mockStorage.On("GetPresignedURL", ctx, "documents/1/file.pdf/v2", time.Hour).
 		Return("https://example.com/presigned/v2", nil).Once()
 
-	result, err := uc.DownloadVersion(ctx, 1, 2)
+	result, err := uc.DownloadVersion(ctx, 1, 2, testUploaderID, testActorRole)
 
 	require.NoError(t, err)
 	require.NotNil(t, result)
@@ -439,7 +447,7 @@ func TestVersionUseCase_DownloadVersion_FileNotFound(t *testing.T) {
 
 	mockFileRepo.On("GetByID", ctx, int64(999)).Return(nil, errors.New("not found")).Once()
 
-	result, err := uc.DownloadVersion(ctx, 999, 1)
+	result, err := uc.DownloadVersion(ctx, 999, 1, testUploaderID, testActorRole)
 
 	assert.Error(t, err)
 	assert.Nil(t, result)
@@ -456,12 +464,13 @@ func TestVersionUseCase_DownloadVersion_VersionNotFound(t *testing.T) {
 		ID:           1,
 		OriginalName: "document.pdf",
 		MimeType:     "application/pdf",
+		UploadedBy:   testUploaderID,
 	}
 
 	mockFileRepo.On("GetByID", ctx, int64(1)).Return(file, nil).Once()
 	mockVersionRepo.On("GetByVersionNumber", ctx, int64(1), 999).Return(nil, errors.New("not found")).Once()
 
-	result, err := uc.DownloadVersion(ctx, 1, 999)
+	result, err := uc.DownloadVersion(ctx, 1, 999, testUploaderID, testActorRole)
 
 	assert.Error(t, err)
 	assert.Nil(t, result)
@@ -476,8 +485,9 @@ func TestVersionUseCase_DownloadVersion_PresignError(t *testing.T) {
 	ctx := context.Background()
 
 	file := &entities.FileMetadata{
-		ID:       1,
-		MimeType: "application/pdf",
+		ID:         1,
+		MimeType:   "application/pdf",
+		UploadedBy: testUploaderID,
 	}
 	version := &entities.FileVersion{
 		ID:         1,
@@ -489,7 +499,7 @@ func TestVersionUseCase_DownloadVersion_PresignError(t *testing.T) {
 	mockStorage.On("GetPresignedURL", ctx, "key/v1", time.Hour).
 		Return("", errors.New("presign error")).Once()
 
-	result, err := uc.DownloadVersion(ctx, 1, 1)
+	result, err := uc.DownloadVersion(ctx, 1, 1, testUploaderID, testActorRole)
 
 	assert.Error(t, err)
 	assert.Nil(t, result)
@@ -526,7 +536,7 @@ func TestVersionUseCase_DeleteVersion_SuccessAsFileOwner(t *testing.T) {
 	mockVersionRepo.On("Delete", ctx, int64(1)).Return(nil).Once()
 	mockAudit.On("LogAuditEvent", ctx, "delete_version", "file", mock.Anything).Once()
 
-	err := uc.DeleteVersion(ctx, 1, 10) // user is file owner
+	err := uc.DeleteVersion(ctx, 1, 10, testActorRole) // user is file owner
 
 	require.NoError(t, err)
 	mockVersionRepo.AssertExpectations(t)
@@ -561,7 +571,7 @@ func TestVersionUseCase_DeleteVersion_SuccessAsVersionCreator(t *testing.T) {
 	mockStorage.On("Delete", ctx, "documents/1/file.pdf/v2").Return(nil).Once()
 	mockVersionRepo.On("Delete", ctx, int64(1)).Return(nil).Once()
 
-	err := uc.DeleteVersion(ctx, 1, 5) // user is version creator
+	err := uc.DeleteVersion(ctx, 1, 5, testActorRole) // user is version creator (kept legitimate)
 
 	require.NoError(t, err)
 }
@@ -586,11 +596,10 @@ func TestVersionUseCase_DeleteVersion_NoPermission(t *testing.T) {
 	mockVersionRepo.On("GetByID", ctx, int64(1)).Return(version, nil).Once()
 	mockFileRepo.On("GetByID", ctx, int64(1)).Return(file, nil).Once()
 
-	err := uc.DeleteVersion(ctx, 1, 99) // user is neither owner nor creator
+	err := uc.DeleteVersion(ctx, 1, 99, testActorRole) // user is neither owner nor creator
 
 	require.Error(t, err)
-	var permErr *PermissionError
-	assert.True(t, errors.As(err, &permErr))
+	assert.True(t, errors.Is(err, filesDomain.ErrFileAccessDenied))
 }
 
 func TestVersionUseCase_DeleteVersion_VersionNotFound(t *testing.T) {
@@ -601,7 +610,7 @@ func TestVersionUseCase_DeleteVersion_VersionNotFound(t *testing.T) {
 
 	mockVersionRepo.On("GetByID", ctx, int64(999)).Return(nil, errors.New("not found")).Once()
 
-	err := uc.DeleteVersion(ctx, 999, 1)
+	err := uc.DeleteVersion(ctx, 999, 1, testActorRole)
 
 	require.Error(t, err)
 }
@@ -622,7 +631,7 @@ func TestVersionUseCase_DeleteVersion_FileGetByIDError(t *testing.T) {
 	mockVersionRepo.On("GetByID", ctx, int64(1)).Return(version, nil).Once()
 	mockFileRepo.On("GetByID", ctx, int64(1)).Return(nil, errors.New("file not found")).Once()
 
-	err := uc.DeleteVersion(ctx, 1, 1)
+	err := uc.DeleteVersion(ctx, 1, 1, testActorRole)
 
 	require.Error(t, err)
 }
@@ -650,7 +659,7 @@ func TestVersionUseCase_DeleteVersion_StorageDeleteError(t *testing.T) {
 	mockFileRepo.On("GetByID", ctx, int64(1)).Return(file, nil).Once()
 	mockStorage.On("Delete", ctx, "key/v1").Return(errors.New("s3 error")).Once()
 
-	err := uc.DeleteVersion(ctx, 1, 1)
+	err := uc.DeleteVersion(ctx, 1, 1, testActorRole)
 
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "ошибка удаления версии из хранилища")
@@ -680,7 +689,7 @@ func TestVersionUseCase_DeleteVersion_RepoDeleteError(t *testing.T) {
 	mockStorage.On("Delete", ctx, "key/v1").Return(nil).Once()
 	mockVersionRepo.On("Delete", ctx, int64(1)).Return(errors.New("db error")).Once()
 
-	err := uc.DeleteVersion(ctx, 1, 1)
+	err := uc.DeleteVersion(ctx, 1, 1, testActorRole)
 
 	require.Error(t, err)
 }
@@ -755,4 +764,89 @@ func TestVersionUseCase_toVersionResponse(t *testing.T) {
 	assert.Equal(t, "Final version", response.Comment)
 	assert.Equal(t, int64(42), response.CreatedBy)
 	assert.Equal(t, now, response.CreatedAt)
+}
+
+// --- ADR-2 CreateVersion ownership + comment sanitize coverage (#290) ---
+
+func TestVersionUseCase_CreateVersion_OtherUserDenied(t *testing.T) {
+	mockFileRepo := new(MockFileMetadataRepository)
+	mockVersionRepo := new(MockFileVersionRepository)
+	mockAudit := new(MockAuditLogger)
+	uc := newTestVersionUseCase(mockFileRepo, mockVersionRepo, nil, mockAudit)
+	ctx := context.Background()
+
+	file := &entities.FileMetadata{ID: 1, IsTemporary: false, UploadedBy: 10}
+	mockFileRepo.On("GetByID", ctx, int64(1)).Return(file, nil).Once()
+	mockAudit.On("LogAuditEvent", ctx, "file_create_version_denied", "file", mock.MatchedBy(func(f map[string]interface{}) bool {
+		return f["actor_user_id"] == int64(99) && f["target_file_id"] == int64(1)
+	})).Once()
+
+	input := &dto.CreateVersionInput{FileID: 1, UserID: 99, UserRole: testActorRole}
+	resp, err := uc.CreateVersion(ctx, bytes.NewReader([]byte("x")), 1, input)
+
+	assert.Nil(t, resp)
+	assert.True(t, errors.Is(err, filesDomain.ErrFileAccessDenied))
+	mockAudit.AssertExpectations(t)
+}
+
+func TestVersionUseCase_CreateVersion_CommentSanitizedAgainstXSS(t *testing.T) {
+	mockFileRepo := new(MockFileMetadataRepository)
+	mockVersionRepo := new(MockFileVersionRepository)
+	mockStorage := new(MockStorageClient)
+	mockAudit := new(MockAuditLogger)
+	uc := newTestVersionUseCase(mockFileRepo, mockVersionRepo, mockStorage, mockAudit)
+	ctx := context.Background()
+
+	file := &entities.FileMetadata{
+		ID:          1,
+		StorageKey:  "documents/1/file.pdf",
+		MimeType:    "application/pdf",
+		IsTemporary: false,
+		UploadedBy:  1,
+	}
+
+	var capturedVersion *entities.FileVersion
+	mockFileRepo.On("GetByID", ctx, int64(1)).Return(file, nil).Once()
+	mockVersionRepo.On("GetNextVersionNumber", ctx, int64(1)).Return(1, nil).Once()
+	mockStorage.On("Upload", ctx, "documents/1/file.pdf/v1", mock.Anything, int64(4), "application/pdf").
+		Return(&storage.FileInfo{Size: 4}, nil).Once()
+	mockVersionRepo.On("Create", ctx, mock.AnythingOfType("*entities.FileVersion")).
+		Run(func(args mock.Arguments) {
+			capturedVersion = args.Get(1).(*entities.FileVersion)
+		}).
+		Return(nil).Once()
+	mockAudit.On("LogAuditEvent", ctx, "create_version", "file", mock.MatchedBy(func(f map[string]interface{}) bool {
+		comment, _ := f["comment"].(string)
+		return !strings.Contains(comment, "<script>")
+	})).Once()
+
+	input := &dto.CreateVersionInput{
+		FileID:   1,
+		Comment:  "<script>alert('xss')</script>legit comment",
+		UserID:   1,
+		UserRole: testActorRole,
+	}
+	resp, err := uc.CreateVersion(ctx, bytes.NewReader([]byte("data")), 4, input)
+
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	require.NotNil(t, capturedVersion)
+	assert.NotContains(t, capturedVersion.Comment, "<script>", "stored comment must be sanitized")
+}
+
+func TestVersionUseCase_DownloadVersion_OtherUserDenied(t *testing.T) {
+	mockFileRepo := new(MockFileMetadataRepository)
+	mockAudit := new(MockAuditLogger)
+	uc := newTestVersionUseCase(mockFileRepo, nil, nil, mockAudit)
+	ctx := context.Background()
+
+	file := &entities.FileMetadata{ID: 1, UploadedBy: testUploaderID}
+	mockFileRepo.On("GetByID", ctx, int64(1)).Return(file, nil).Once()
+	mockAudit.On("LogAuditEvent", ctx, "file_read_denied", "file", mock.Anything).Once()
+
+	result, err := uc.DownloadVersion(ctx, 1, 2, 99, testActorRole)
+
+	assert.Nil(t, result)
+	assert.True(t, errors.Is(err, filesDomain.ErrFileAccessDenied))
+	mockAudit.AssertExpectations(t)
 }

--- a/internal/modules/files/interfaces/http/handlers/file_handler.go
+++ b/internal/modules/files/interfaces/http/handlers/file_handler.go
@@ -329,21 +329,20 @@ func (h *FileHandler) CreateVersion(c *gin.Context) {
 	}
 	defer func() { _ = file.Close() }()
 
-	// Получаем user_id из контекста
-	userIDVal, exists := c.Get("user_id")
-	if !exists {
+	actorID, actorRole, ok := readActor(c)
+	if !ok {
 		resp := response.Unauthorized("Требуется авторизация")
 		c.JSON(http.StatusUnauthorized, resp)
 		return
 	}
-	userID, _ := userIDVal.(int64)
 
 	comment := c.PostForm("comment")
 
 	input := &dto.CreateVersionInput{
-		FileID:  id,
-		Comment: comment,
-		UserID:  userID,
+		FileID:   id,
+		Comment:  comment,
+		UserID:   actorID,
+		UserRole: actorRole,
 	}
 
 	ctx := c.Request.Context()
@@ -399,8 +398,15 @@ func (h *FileHandler) DownloadVersion(c *gin.Context) {
 		return
 	}
 
+	actorID, actorRole, ok := readActor(c)
+	if !ok {
+		resp := response.Unauthorized("Требуется авторизация")
+		c.JSON(http.StatusUnauthorized, resp)
+		return
+	}
+
 	ctx := c.Request.Context()
-	result, err := h.versionUseCase.DownloadVersion(ctx, id, versionNumber)
+	result, err := h.versionUseCase.DownloadVersion(ctx, id, versionNumber, actorID, actorRole)
 	if err != nil {
 		httpErr := response.MapDomainError(err)
 		c.JSON(httpErr.Status, httpErr.Response)

--- a/internal/modules/files/interfaces/http/handlers/file_handler_usecase_test.go
+++ b/internal/modules/files/interfaces/http/handlers/file_handler_usecase_test.go
@@ -130,7 +130,9 @@ var _ repositories.FileMetadataRepository = (*fakeFileMetaRepo)(nil)
 //
 // role mirrors auth/middleware behavior — defaults to student if caller
 // omits it (most tests want the uploader case where role doesn't matter
-// for the rule, only id-match does).
+// for the rule, only id-match does). Role is stored as plain string
+// (matching JWTMiddleware behaviour), so downstream middleware like
+// RequireRole (which type-asserts to string) recognises it.
 func authMW(userID int64, roles ...authDomain.RoleType) gin.HandlerFunc {
 	role := authDomain.RoleStudent
 	if len(roles) > 0 {
@@ -138,7 +140,7 @@ func authMW(userID int64, roles ...authDomain.RoleType) gin.HandlerFunc {
 	}
 	return func(c *gin.Context) {
 		c.Set("user_id", userID)
-		c.Set("role", role)
+		c.Set("role", string(role))
 		c.Next()
 	}
 }
@@ -388,4 +390,64 @@ func TestFileHandler_GetByID_HappyPath(t *testing.T) {
 	r.ServeHTTP(w, req)
 
 	require.Equal(t, http.StatusOK, w.Code)
+}
+
+// ----- ADR-5 cleanup admin gate (#290) -----
+
+// setupCleanupRouter wires authMW + RequireRole("system_admin") in front
+// of the cleanup handler — mirrors production main.go route assembly.
+func setupCleanupRouter(h *FileHandler, role authDomain.RoleType) *gin.Engine {
+	r := gin.New()
+	r.Use(authMW(defaultFixtureUploader, role))
+	cleanupGroup := r.Group("")
+	cleanupGroup.Use(authMiddlewareRequireSystemAdmin())
+	cleanupGroup.POST("/files/cleanup", h.CleanupExpired)
+	return r
+}
+
+// authMiddlewareRequireSystemAdmin returns a gin.HandlerFunc enforcing
+// role == "system_admin" — mirrors auth_middleware.RequireRole inline
+// so tests don't need the auth package as a dependency.
+func authMiddlewareRequireSystemAdmin() gin.HandlerFunc {
+	return func(c *gin.Context) {
+		userRole, exists := c.Get("role")
+		if !exists {
+			c.AbortWithStatus(http.StatusForbidden)
+			return
+		}
+		roleStr, ok := userRole.(string)
+		if !ok || roleStr != string(authDomain.RoleSystemAdmin) {
+			c.AbortWithStatus(http.StatusForbidden)
+			return
+		}
+		c.Next()
+	}
+}
+
+func TestFileHandler_CleanupExpired_StudentDenied(t *testing.T) {
+	repo := &fakeFileMetaRepo{}
+	h := newHandlerWithUC(repo)
+	r := setupCleanupRouter(h, authDomain.RoleStudent)
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/files/cleanup", nil)
+	r.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusForbidden, w.Code,
+		"student must be rejected by RequireRole(system_admin) middleware")
+	assert.False(t, repo.cleanupCalled, "cleanup handler must not run for non-admin")
+}
+
+func TestFileHandler_CleanupExpired_AdminAllowed(t *testing.T) {
+	repo := &fakeFileMetaRepo{count: 0}
+	h := newHandlerWithUC(repo)
+	r := setupCleanupRouter(h, authDomain.RoleSystemAdmin)
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/files/cleanup", nil)
+	r.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code,
+		"system_admin must pass RequireRole gate and reach the handler")
+	assert.True(t, repo.cleanupCalled, "cleanup handler should have run")
 }

--- a/internal/modules/files/interfaces/http/handlers/file_handler_usecase_test.go
+++ b/internal/modules/files/interfaces/http/handlers/file_handler_usecase_test.go
@@ -131,8 +131,8 @@ var _ repositories.FileMetadataRepository = (*fakeFileMetaRepo)(nil)
 // role mirrors auth/middleware behavior — defaults to student if caller
 // omits it (most tests want the uploader case where role doesn't matter
 // for the rule, only id-match does). Role is stored as plain string
-// (matching JWTMiddleware behaviour), so downstream middleware like
-// RequireRole (which type-asserts to string) recognises it.
+// (matching JWTMiddleware behavior), so downstream middleware like
+// RequireRole (which type-asserts to string) recognizes it.
 func authMW(userID int64, roles ...authDomain.RoleType) gin.HandlerFunc {
 	role := authDomain.RoleStudent
 	if len(roles) > 0 {

--- a/internal/shared/infrastructure/storage/file_validator.go
+++ b/internal/shared/infrastructure/storage/file_validator.go
@@ -158,6 +158,26 @@ func (v *FileValidator) ValidateFile(fileName string, fileSize int64, contentTyp
 				}
 			}
 		}
+
+		// Closes #290 ADR-3 octet-stream loophole: when content-type is
+		// application/octet-stream (the generic "I don't know" value
+		// sent by curl и by clients that strip MIME), require magic-
+		// byte detection to yield a whitelisted type. Otherwise evil.exe
+		// (PE: 0x4D 0x5A) sent с octet-stream slips через the MIME
+		// check entirely.
+		if contentType == "" || contentType == "application/octet-stream" {
+			if result.DetectedType == "" || !v.allowedMimeTypes[result.DetectedType] {
+				result.Valid = false
+				detectedLabel := result.DetectedType
+				if detectedLabel == "" {
+					detectedLabel = "неизвестный"
+				}
+				result.Errors = append(result.Errors, fmt.Sprintf(
+					"Тип файла не определён или не разрешён (обнаружено: %s)",
+					detectedLabel,
+				))
+			}
+		}
 	}
 
 	return result, nil

--- a/internal/shared/infrastructure/storage/file_validator_test.go
+++ b/internal/shared/infrastructure/storage/file_validator_test.go
@@ -228,12 +228,37 @@ func TestValidateFile_MagicBytes(t *testing.T) {
 			wantType:    "image/png",
 		},
 		{
+			// #290 ADR-3 loophole closed: octet-stream + unknown magic
+			// bytes used to slip through, letting evil.exe (declared
+			// octet-stream) upload freely. ValidateFile now requires the
+			// detected type to be whitelisted when MIME declares
+			// octet-stream — unknown bytes here yield Valid=false.
 			name:        "unknown magic bytes with octet-stream",
 			fileName:    "data.txt",
 			contentType: "application/octet-stream",
 			magicBytes:  []byte{0x00, 0x01, 0x02, 0x03},
-			wantValid:   true,
+			wantValid:   false,
 			wantType:    "",
+		},
+		{
+			// #290 ADR-3 explicit coverage for the evil.exe case: PE
+			// magic (4D 5A) declared octet-stream → reject.
+			name:        "evil.exe declared as octet-stream",
+			fileName:    "evil.exe",
+			contentType: "application/octet-stream",
+			magicBytes:  []byte{0x4D, 0x5A, 0x00, 0x00},
+			wantValid:   false,
+			wantType:    "",
+		},
+		{
+			// #290 ADR-3 positive path: octet-stream + whitelisted
+			// magic (PDF here) → accept (detected type lookup succeeds).
+			name:        "PDF declared as octet-stream → accepted via magic",
+			fileName:    "report.pdf",
+			contentType: "application/octet-stream",
+			magicBytes:  []byte{0x25, 0x50, 0x44, 0x46, 0x2D},
+			wantValid:   true,
+			wantType:    "application/pdf",
 		},
 		{
 			name:        "docx detected as zip related type",


### PR DESCRIPTION
## Summary

Second of 3 split PRs for v0.161.0 files Tier 1 security hotfix (#290). Builds on PR #292 (PR-A merged 897ddcd0). Closes 3 more ADRs from the 5-ADR plan; ADR-1 already in PR-A; ADR-4 deferred to v0.161.1.

- **ADR-2** — gate CreateVersion + DeleteVersion + DownloadVersion via AuthorizeFileAccess; sanitize version comment
- **ADR-3** — wire full ValidateFile (MIME + size + ext); close octet-stream loophole on upload
- **ADR-5** — admin-only gate on /api/files/cleanup
- **misspell** — BrE→AmE sweep + plan doc note for deferred ADR-4

## Test plan

- [x] go build ./... clean
- [x] gofmt -l clean
- [x] golangci-lint --config=.github/golangci.yml clean (0 issues)
- [x] go test ./internal/modules/files/... ./internal/shared/infrastructure/storage/... pass
- [ ] CI Backend (Lint+Format+PR Size+Unit+Integration)
- [ ] CI Security (CodeQL+Trivy+gosec+secret scan)

## Related

- Closes ADR-2 + ADR-3 + ADR-5 of #290 (final closure on PR-C release commit)
- Split per `feedback_phase_split_pr_size_gate` (PR Size 1000-line hard gate)
- PR-A (foundation + ADR-1): #292 ✅ merged
- PR-C (FIX-CYCLE + release commit, closes #290): next