### PR TITLE
chore(ci): expand PR Validation scope allowlist (closes #299)

### DIFF
--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -56,6 +56,18 @@ jobs:
           notifications
           files
           integration
+          messaging
+          announcements
+          ai
+          branding
+          curriculum
+          assignments
+          analytics
+          dashboard
+          reports
+          gitignore
+          deps
+          husky
         requireScope: false
 
     - name: Checkout code


### PR DESCRIPTION
## Summary

Closes #299. Adds 11 missing scopes to \`.github/workflows/pr-validation.yml\` allowlist:

- **messaging** — blocks PR #298 v0.162.0 hotfix
- **announcements** — will block v0.163.0 hotfix
- **ai, branding, curriculum, assignments, analytics, dashboard, reports** — active modules with prior shipped PRs
- **gitignore** — blocks PR #296
- **deps, husky** — dependabot + tooling scopes

No CI gates relaxed: existing 16 scopes retained; only adds entries для real module names that should have been there from start.

## Test plan

- [x] yaml parses (manually verified)
- [ ] Self-PR Validation passes with \`chore(ci):\` scope
- [ ] After merge: PR #298 and PR #296 re-validate green on title check