### PR TITLE
chore(config): exclude personal artifacts + plan drafts in .gitignore (closes #300)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -136,8 +136,31 @@ runtime-state/
 SERVER_ADMIN.md
 
 # Local-only plan drafts and demo seed (not part of product code).
-# Other docs/plans/*.md files ARE tracked — these specific dated drafts
-# were committed by accident and untracked retroactively.
+# Plan drafts начиная с 2026-* — рабочие черновики Даниила для конкретных
+# фич/релизов; не часть продуктового кода. Уже tracked-плановые файлы
+# остаются tracked (git правило: pattern не выкидывает existing tracked).
 docs/plans/2026-04-26-resource-permission-matrix.md
 docs/plans/2026-04-27-schedule-lessons.md
+docs/plans/2026-*.md
 migrations/seed_demo_data.sql
+
+# docs/roles-and-flows.md — brief для научрука. Обновляется локально
+# каждый релиз, но в git не пушится через PR. Файл остаётся tracked
+# (его история есть в репо), но новые правки — local-only working tree.
+# Это правило установлено 2026-05-23 пост v0.161.0.
+
+# Personal / local-only thesis & diploma artifacts (acts, scenarios,
+# diagrams, master-thesis math model chapter, Claude session handoffs).
+# Эти файлы — рабочие материалы Даниила для диплома/защиты, не часть
+# продуктового кода. Не пушить в GitHub.
+NEXT_SESSION_PROMPT.md
+/Akt_*.docx
+/Akt_*.pages
+/Polozheniya_*.docx
+/Analiz_*.docx
+/BPMN_*.docx
+/*.drawio
+docs/master-thesis/
+docs/Сценарии_*.docx
+docs/use-case-*.drawio
+docs/idef0_*.drawio


### PR DESCRIPTION
## Summary

Closes #300. Re-creation of #296 on a branch that matches the project convention \`chore/issue-N-...\` (the previous branch \`chore/gitignore-...\` failed branch-name validation).

Расширяет .gitignore:

- Claude session handoffs (\`NEXT_SESSION_PROMPT.md\`)
- Личные thesis-документы: \`Akt_*.docx\`, \`Polozheniya_*.docx\`, \`Analiz_*.docx\`, \`BPMN_*.docx\`, \`*.drawio\`, \`*.pages\`
- \`docs/master-thesis/\` (мат модель)
- Russian-named docs (\`Сценарии_*.docx\`, \`use-case-*.drawio\`, \`idef0_*.drawio\`)
- \`docs/plans/2026-*.md\` catch-all (16 уже tracked планов остаются tracked per git rule)

Добавляет правило: \`docs/roles-and-flows.md\` остаётся tracked, но обновляется local-only working tree без PR.

## Test plan

- [x] \`git status\` чистый после расширения
- [x] tracked plan docs не затронуты (16 файлов в \`git ls-files docs/plans/\`)
- [x] branch name matches \`^(feature|task|bugfix|hotfix|config|chore|docs|refactor)/issue-N-...\` pattern
- [ ] CI Validate PR Metadata + markdownlint