### PR TITLE
feat(extracurricular): v0.162.0a — domain pairs 1+2 (constructor + VOs)

### DIFF
--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -61,6 +61,7 @@ jobs:
           ai
           branding
           curriculum
+          extracurricular
           assignments
           analytics
           dashboard

--- a/internal/modules/extracurricular/domain/entities/event.go
+++ b/internal/modules/extracurricular/domain/entities/event.go
@@ -2,6 +2,8 @@ package entities
 
 import (
 	"errors"
+	"fmt"
+	"strings"
 	"time"
 )
 
@@ -106,7 +108,7 @@ const (
 // NewExtracurricularEvent validates invariants and returns a fresh
 // event in draft status at version 0 (optimistic-locking baseline).
 //
-// Invariants (Pair 1 RED stub — Pair 1 GREEN implements):
+// Invariants (mirroring SQL CHECK constraints в migration 046):
 //   - organizer_id > 0
 //   - title trimmed-non-empty, ≤ 255 runes
 //   - description ≤ 4096 runes (blank OK)
@@ -115,8 +117,98 @@ const (
 //   - target_audience.IsValid()
 //   - start_at < end_at
 //   - max_capacity nil OR ≥ 0
+//
+// Each violation wraps ErrInvalidEvent с the offending field so
+// errors.Is resolves the sentinel for the 422 mapping в handlers.
 func NewExtracurricularEvent(p NewExtracurricularEventParams) (*ExtracurricularEvent, error) {
-	return nil, errors.New("not implemented (Pair 1 RED stub)")
+	if p.OrganizerID <= 0 {
+		return nil, fmt.Errorf("%w: organizer_id must be positive, got %d",
+			ErrInvalidEvent, p.OrganizerID)
+	}
+	title := strings.TrimSpace(p.Title)
+	if title == "" {
+		return nil, fmt.Errorf("%w: title must not be empty", ErrInvalidEvent)
+	}
+	if len([]rune(title)) > maxEventTitleLen {
+		return nil, fmt.Errorf("%w: title length %d exceeds max %d",
+			ErrInvalidEvent, len([]rune(title)), maxEventTitleLen)
+	}
+	description := strings.TrimSpace(p.Description)
+	if len([]rune(description)) > maxEventDescriptionLen {
+		return nil, fmt.Errorf("%w: description length %d exceeds max %d",
+			ErrInvalidEvent, len([]rune(description)), maxEventDescriptionLen)
+	}
+	location := strings.TrimSpace(p.Location)
+	if len([]rune(location)) > maxEventLocationLen {
+		return nil, fmt.Errorf("%w: location length %d exceeds max %d",
+			ErrInvalidEvent, len([]rune(location)), maxEventLocationLen)
+	}
+	if !p.Category.IsValid() {
+		return nil, fmt.Errorf("%w: invalid category %q", ErrInvalidEvent, p.Category)
+	}
+	if !p.TargetAudience.IsValid() {
+		return nil, fmt.Errorf("%w: invalid target_audience %q", ErrInvalidEvent, p.TargetAudience)
+	}
+	if !p.StartAt.Before(p.EndAt) {
+		return nil, fmt.Errorf("%w: start_at (%v) must be before end_at (%v)",
+			ErrInvalidEvent, p.StartAt, p.EndAt)
+	}
+	if p.MaxCapacity != nil && *p.MaxCapacity < 0 {
+		return nil, fmt.Errorf("%w: max_capacity must be non-negative, got %d",
+			ErrInvalidEvent, *p.MaxCapacity)
+	}
+	return &ExtracurricularEvent{
+		title:          title,
+		description:    description,
+		category:       p.Category,
+		targetAudience: p.TargetAudience,
+		status:         StatusDraft,
+		location:       location,
+		startAt:        p.StartAt,
+		endAt:          p.EndAt,
+		maxCapacity:    p.MaxCapacity,
+		organizerID:    p.OrganizerID,
+		participants:   nil,
+		version:        0,
+		createdAt:      p.Now,
+		updatedAt:      p.Now,
+	}, nil
+}
+
+// ReconstituteExtracurricularEvent rebuilds an event from authoritative
+// storage без re-validating invariants — DB CHECKs are the canonical
+// gate at write time. Used exclusively by repository implementations.
+func ReconstituteExtracurricularEvent(
+	id int64,
+	title, description string,
+	category Category,
+	targetAudience TargetAudience,
+	status Status,
+	location string,
+	startAt, endAt time.Time,
+	maxCapacity *int,
+	organizerID int64,
+	participants []Participant,
+	version int,
+	createdAt, updatedAt time.Time,
+) *ExtracurricularEvent {
+	return &ExtracurricularEvent{
+		ID:             id,
+		title:          title,
+		description:    description,
+		category:       category,
+		targetAudience: targetAudience,
+		status:         status,
+		location:       location,
+		startAt:        startAt,
+		endAt:          endAt,
+		maxCapacity:    maxCapacity,
+		organizerID:    organizerID,
+		participants:   participants,
+		version:        version,
+		createdAt:      createdAt,
+		updatedAt:      updatedAt,
+	}
 }
 
 // Title returns the human-readable event title.

--- a/internal/modules/extracurricular/domain/entities/event.go
+++ b/internal/modules/extracurricular/domain/entities/event.go
@@ -1,0 +1,166 @@
+package entities
+
+import (
+	"errors"
+	"time"
+)
+
+// ErrInvalidEvent signals a violation of one of the
+// ExtracurricularEvent construction or update invariants (empty title,
+// oversize fields, non-chronological time range, invalid VO, negative
+// capacity, non-positive organizer_id). Handlers map this sentinel to
+// HTTP 422.
+var ErrInvalidEvent = errors.New("extracurricular_event: invalid event")
+
+// ErrEventScopeForbidden indicates that a caller is not authorized to
+// mutate or view the event — typically because the caller is not the
+// organizer and not an admin. Handlers map this sentinel to HTTP 403.
+var ErrEventScopeForbidden = errors.New("extracurricular_event: caller cannot operate on this event")
+
+// ErrCannotEditEvent indicates the event is in a terminal status
+// (canceled or completed) that does not permit edits per ADR-2.
+// Handlers map this sentinel to HTTP 422.
+var ErrCannotEditEvent = errors.New("extracurricular_event: cannot edit in current status")
+
+// ErrParticipantExists indicates a double-registration attempt — the
+// user already has a participant row for this event. Handlers map this
+// sentinel to HTTP 409.
+var ErrParticipantExists = errors.New("extracurricular_event: participant already registered")
+
+// ErrParticipantNotFound indicates Unregister was called for a user
+// that was not previously registered. Handlers map this sentinel to
+// HTTP 404.
+var ErrParticipantNotFound = errors.New("extracurricular_event: participant not registered")
+
+// ErrEventFull indicates a registration attempt against an event that
+// has reached its max_capacity. Handlers map this sentinel to HTTP 409.
+var ErrEventFull = errors.New("extracurricular_event: event at full capacity")
+
+// ErrEventNotOpenForRegistration indicates registration was attempted
+// against an event that is not in the `published` status (draft event
+// is not yet visible; canceled/completed are terminal). Handlers map
+// this sentinel to HTTP 422.
+var ErrEventNotOpenForRegistration = errors.New("extracurricular_event: event not open for registration")
+
+// ExtracurricularEvent is the aggregate root for внеучебных
+// мероприятий per ADR-1 (plan 2026-05-24-b3-extracurricular.md).
+// Participants are inner entities — accessed only through aggregate
+// methods (Register / Unregister / HasParticipant) so the
+// capacity invariant `len(participants) <= maxCapacity` стой within
+// the transactional boundary.
+//
+// Lifecycle (ADR-2): status drives editability and registration
+// eligibility. Optimistic locking (ADR-5): version bumps on every
+// successful write; UPDATE WHERE version=? → 409 on race.
+type ExtracurricularEvent struct {
+	ID             int64
+	title          string
+	description    string
+	category       Category
+	targetAudience TargetAudience
+	status         Status
+	location       string
+	startAt        time.Time
+	endAt          time.Time
+	maxCapacity    *int
+	organizerID    int64
+	participants   []Participant
+	version        int
+	createdAt      time.Time
+	updatedAt      time.Time
+}
+
+// Participant is an inner entity of the ExtracurricularEvent aggregate
+// representing one user's registration for the event. Persisted to a
+// separate table (extracurricular_participants) but loaded together
+// with the parent event on aggregate fetch.
+type Participant struct {
+	UserID       int64
+	RegisteredAt time.Time
+}
+
+// NewExtracurricularEventParams bundles the constructor inputs to keep
+// call sites readable as optional fields accumulate (mirror к
+// NewSectionParams pattern).
+type NewExtracurricularEventParams struct {
+	Title          string
+	Description    string
+	Category       Category
+	TargetAudience TargetAudience
+	Location       string
+	StartAt        time.Time
+	EndAt          time.Time
+	MaxCapacity    *int // nil = unlimited
+	OrganizerID    int64
+	Now            time.Time
+}
+
+// Event text-field bounds — mirrored by SQL CHECK constraints в
+// migration 046.
+const (
+	maxEventTitleLen       = 255
+	maxEventDescriptionLen = 4096
+	maxEventLocationLen    = 255
+)
+
+// NewExtracurricularEvent validates invariants and returns a fresh
+// event in draft status at version 0 (optimistic-locking baseline).
+//
+// Invariants (Pair 1 RED stub — Pair 1 GREEN implements):
+//   - organizer_id > 0
+//   - title trimmed-non-empty, ≤ 255 runes
+//   - description ≤ 4096 runes (blank OK)
+//   - location ≤ 255 runes (blank OK)
+//   - category.IsValid()
+//   - target_audience.IsValid()
+//   - start_at < end_at
+//   - max_capacity nil OR ≥ 0
+func NewExtracurricularEvent(p NewExtracurricularEventParams) (*ExtracurricularEvent, error) {
+	return nil, errors.New("not implemented (Pair 1 RED stub)")
+}
+
+// Title returns the human-readable event title.
+func (e *ExtracurricularEvent) Title() string { return e.title }
+
+// Description returns the optional free-form description.
+func (e *ExtracurricularEvent) Description() string { return e.description }
+
+// Category returns the event classification (cultural/sports/...).
+func (e *ExtracurricularEvent) Category() Category { return e.category }
+
+// TargetAudience returns the role-cohort eligible to see + register.
+func (e *ExtracurricularEvent) TargetAudience() TargetAudience { return e.targetAudience }
+
+// Status returns the lifecycle state.
+func (e *ExtracurricularEvent) Status() Status { return e.status }
+
+// Location returns the venue (optional).
+func (e *ExtracurricularEvent) Location() string { return e.location }
+
+// StartAt returns the scheduled start timestamp.
+func (e *ExtracurricularEvent) StartAt() time.Time { return e.startAt }
+
+// EndAt returns the scheduled end timestamp.
+func (e *ExtracurricularEvent) EndAt() time.Time { return e.endAt }
+
+// MaxCapacity returns the participant cap; nil means unlimited.
+func (e *ExtracurricularEvent) MaxCapacity() *int { return e.maxCapacity }
+
+// OrganizerID returns the FK to users.id of the organizer.
+func (e *ExtracurricularEvent) OrganizerID() int64 { return e.organizerID }
+
+// Participants returns a defensive copy of the participants slice.
+func (e *ExtracurricularEvent) Participants() []Participant {
+	out := make([]Participant, len(e.participants))
+	copy(out, e.participants)
+	return out
+}
+
+// Version returns the optimistic-locking version.
+func (e *ExtracurricularEvent) Version() int { return e.version }
+
+// CreatedAt returns the creation timestamp.
+func (e *ExtracurricularEvent) CreatedAt() time.Time { return e.createdAt }
+
+// UpdatedAt returns the last-mutation timestamp.
+func (e *ExtracurricularEvent) UpdatedAt() time.Time { return e.updatedAt }

--- a/internal/modules/extracurricular/domain/entities/event_test.go
+++ b/internal/modules/extracurricular/domain/entities/event_test.go
@@ -1,0 +1,216 @@
+package entities
+
+import (
+	"errors"
+	"strings"
+	"testing"
+	"time"
+)
+
+// validEventParams returns a syntactically valid NewExtracurricularEventParams
+// instance to use as baseline в invariant-violation tests. Tests mutate
+// one field at a time to isolate each invariant (mirror к
+// validSectionParams).
+func validEventParams(now time.Time) NewExtracurricularEventParams {
+	return NewExtracurricularEventParams{
+		Title:          "Концерт ко Дню учителя",
+		Description:    "Праздничный концерт силами студенческого театра",
+		Category:       CategoryCultural,
+		TargetAudience: TargetAudienceAll,
+		Location:       "Актовый зал, корпус 2",
+		StartAt:        now.Add(48 * time.Hour),
+		EndAt:          now.Add(50 * time.Hour),
+		MaxCapacity:    nil,
+		OrganizerID:    42,
+		Now:            now,
+	}
+}
+
+func TestNewExtracurricularEvent_HappyPath(t *testing.T) {
+	now := time.Date(2026, 5, 24, 12, 0, 0, 0, time.UTC)
+	e, err := NewExtracurricularEvent(validEventParams(now))
+	if err != nil {
+		t.Fatalf("NewExtracurricularEvent returned unexpected error: %v", err)
+	}
+	if e == nil {
+		t.Fatal("NewExtracurricularEvent returned nil entity with no error")
+	}
+	if got, want := e.Title(), "Концерт ко Дню учителя"; got != want {
+		t.Errorf("Title() = %q, want %q", got, want)
+	}
+	if got, want := e.Category(), CategoryCultural; got != want {
+		t.Errorf("Category() = %q, want %q", got, want)
+	}
+	if got, want := e.TargetAudience(), TargetAudienceAll; got != want {
+		t.Errorf("TargetAudience() = %q, want %q", got, want)
+	}
+	if got, want := e.Status(), StatusDraft; got != want {
+		t.Errorf("Status() = %q, want %q (fresh events default to draft)", got, want)
+	}
+	if got, want := e.OrganizerID(), int64(42); got != want {
+		t.Errorf("OrganizerID() = %d, want %d", got, want)
+	}
+	if got, want := e.Version(), 0; got != want {
+		t.Errorf("Version() = %d, want %d for fresh event", got, want)
+	}
+	if e.MaxCapacity() != nil {
+		t.Errorf("MaxCapacity() = %v, want nil for unlimited", e.MaxCapacity())
+	}
+	if !e.CreatedAt().Equal(now) {
+		t.Errorf("CreatedAt() = %v, want %v", e.CreatedAt(), now)
+	}
+	if !e.UpdatedAt().Equal(now) {
+		t.Errorf("UpdatedAt() = %v, want %v", e.UpdatedAt(), now)
+	}
+	if len(e.Participants()) != 0 {
+		t.Errorf("Participants() = %v, want empty for fresh event", e.Participants())
+	}
+}
+
+func TestNewExtracurricularEvent_TrimsTextFields(t *testing.T) {
+	now := time.Now()
+	p := validEventParams(now)
+	p.Title = "  Концерт ко Дню учителя  "
+	p.Description = "  Праздничный концерт  "
+	p.Location = "  Актовый зал  "
+	e, err := NewExtracurricularEvent(p)
+	if err != nil {
+		t.Fatalf("NewExtracurricularEvent returned unexpected error: %v", err)
+	}
+	if got, want := e.Title(), "Концерт ко Дню учителя"; got != want {
+		t.Errorf("Title() = %q, want trimmed canonical form %q", got, want)
+	}
+	if got, want := e.Description(), "Праздничный концерт"; got != want {
+		t.Errorf("Description() = %q, want trimmed %q", got, want)
+	}
+	if got, want := e.Location(), "Актовый зал"; got != want {
+		t.Errorf("Location() = %q, want trimmed %q", got, want)
+	}
+}
+
+func TestNewExtracurricularEvent_AcceptsBlankOptionalFields(t *testing.T) {
+	now := time.Now()
+	p := validEventParams(now)
+	p.Description = ""
+	p.Location = ""
+	e, err := NewExtracurricularEvent(p)
+	if err != nil {
+		t.Fatalf("NewExtracurricularEvent returned unexpected error: %v", err)
+	}
+	if got := e.Description(); got != "" {
+		t.Errorf("Description() = %q, want empty for blank input", got)
+	}
+	if got := e.Location(); got != "" {
+		t.Errorf("Location() = %q, want empty for blank input", got)
+	}
+}
+
+func TestNewExtracurricularEvent_InvariantViolations(t *testing.T) {
+	now := time.Date(2026, 5, 24, 12, 0, 0, 0, time.UTC)
+	tests := []struct {
+		name    string
+		mutate  func(*NewExtracurricularEventParams)
+		wantErr error
+	}{
+		{
+			name:    "empty title",
+			mutate:  func(p *NewExtracurricularEventParams) { p.Title = "   " },
+			wantErr: ErrInvalidEvent,
+		},
+		{
+			name: "oversize title",
+			mutate: func(p *NewExtracurricularEventParams) {
+				p.Title = strings.Repeat("ы", maxEventTitleLen+1)
+			},
+			wantErr: ErrInvalidEvent,
+		},
+		{
+			name: "oversize description",
+			mutate: func(p *NewExtracurricularEventParams) {
+				p.Description = strings.Repeat("а", maxEventDescriptionLen+1)
+			},
+			wantErr: ErrInvalidEvent,
+		},
+		{
+			name: "oversize location",
+			mutate: func(p *NewExtracurricularEventParams) {
+				p.Location = strings.Repeat("л", maxEventLocationLen+1)
+			},
+			wantErr: ErrInvalidEvent,
+		},
+		{
+			name:    "non-positive organizer_id",
+			mutate:  func(p *NewExtracurricularEventParams) { p.OrganizerID = 0 },
+			wantErr: ErrInvalidEvent,
+		},
+		{
+			name:    "negative organizer_id",
+			mutate:  func(p *NewExtracurricularEventParams) { p.OrganizerID = -1 },
+			wantErr: ErrInvalidEvent,
+		},
+		{
+			name: "start_at equal end_at",
+			mutate: func(p *NewExtracurricularEventParams) {
+				t0 := now.Add(48 * time.Hour)
+				p.StartAt = t0
+				p.EndAt = t0
+			},
+			wantErr: ErrInvalidEvent,
+		},
+		{
+			name: "start_at after end_at",
+			mutate: func(p *NewExtracurricularEventParams) {
+				p.StartAt = now.Add(50 * time.Hour)
+				p.EndAt = now.Add(48 * time.Hour)
+			},
+			wantErr: ErrInvalidEvent,
+		},
+		{
+			name: "negative max_capacity",
+			mutate: func(p *NewExtracurricularEventParams) {
+				neg := -1
+				p.MaxCapacity = &neg
+			},
+			wantErr: ErrInvalidEvent,
+		},
+		// invalid_category + invalid_target_audience deferred к Pair 2
+		// (VO IsValid() restrictive impl). Pair 1 GREEN still calls
+		// IsValid() on both fields, but the stub returns always-true so
+		// Pair 1 cannot fail those cases.
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			p := validEventParams(now)
+			tt.mutate(&p)
+			e, err := NewExtracurricularEvent(p)
+			if err == nil {
+				t.Fatalf("NewExtracurricularEvent expected error, got nil event=%+v", e)
+			}
+			if !errors.Is(err, tt.wantErr) {
+				t.Errorf("NewExtracurricularEvent error = %v, want errors.Is(%v)", err, tt.wantErr)
+			}
+			if e != nil {
+				t.Errorf("NewExtracurricularEvent returned non-nil entity on invariant violation: %+v", e)
+			}
+		})
+	}
+}
+
+func TestNewExtracurricularEvent_AcceptsZeroMaxCapacity(t *testing.T) {
+	// max_capacity == 0 is semantically distinct from nil — a zero-cap
+	// event is valid construction-wise (e.g. for "view-only" event
+	// pages without registration). Registration attempts will fail с
+	// ErrEventFull. Mirrors the CHECK constraint chk_extracurricular_capacity_nonneg
+	// which accepts ≥ 0.
+	now := time.Now()
+	p := validEventParams(now)
+	zero := 0
+	p.MaxCapacity = &zero
+	e, err := NewExtracurricularEvent(p)
+	if err != nil {
+		t.Fatalf("NewExtracurricularEvent returned unexpected error: %v", err)
+	}
+	if e.MaxCapacity() == nil || *e.MaxCapacity() != 0 {
+		t.Errorf("MaxCapacity() = %v, want pointer to 0", e.MaxCapacity())
+	}
+}

--- a/internal/modules/extracurricular/domain/entities/event_test.go
+++ b/internal/modules/extracurricular/domain/entities/event_test.go
@@ -173,10 +173,26 @@ func TestNewExtracurricularEvent_InvariantViolations(t *testing.T) {
 			},
 			wantErr: ErrInvalidEvent,
 		},
-		// invalid_category + invalid_target_audience deferred к Pair 2
-		// (VO IsValid() restrictive impl). Pair 1 GREEN still calls
-		// IsValid() on both fields, but the stub returns always-true so
-		// Pair 1 cannot fail those cases.
+		{
+			name:    "invalid category",
+			mutate:  func(p *NewExtracurricularEventParams) { p.Category = Category("bogus") },
+			wantErr: ErrInvalidEvent,
+		},
+		{
+			name:    "invalid target_audience",
+			mutate:  func(p *NewExtracurricularEventParams) { p.TargetAudience = TargetAudience("bogus") },
+			wantErr: ErrInvalidEvent,
+		},
+		{
+			name:    "empty category rejected",
+			mutate:  func(p *NewExtracurricularEventParams) { p.Category = Category("") },
+			wantErr: ErrInvalidEvent,
+		},
+		{
+			name:    "empty target_audience rejected",
+			mutate:  func(p *NewExtracurricularEventParams) { p.TargetAudience = TargetAudience("") },
+			wantErr: ErrInvalidEvent,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/internal/modules/extracurricular/domain/entities/value_objects.go
+++ b/internal/modules/extracurricular/domain/entities/value_objects.go
@@ -1,0 +1,85 @@
+package entities
+
+// Category classifies an ExtracurricularEvent по типу деятельности per
+// spec (.taskmaster/docs/2026-05-03-audit-rolling-releases-prd.txt
+// lines 256-258). Five canonical values cover the academic-secretary
+// matrix of внеучебных направлений. Per ADR-3 (plan
+// 2026-05-24-b3-extracurricular.md) the enum is module-local — not
+// reused from announcements/domain/types.go — to keep bounded contexts
+// independent.
+type Category string
+
+// Category canonical values.
+const (
+	CategoryCultural     Category = "cultural"
+	CategorySports       Category = "sports"
+	CategoryRecreational Category = "recreational"
+	CategoryEducational  Category = "educational"
+	CategoryOther        Category = "other"
+)
+
+// IsValid reports whether c is one of the canonical Category values.
+// The Pair 1 RED placeholder accepts everything; Pair 2 GREEN tightens
+// to the const set (mirror ControlForm pattern в curriculum module).
+func (c Category) IsValid() bool {
+	return true
+}
+
+// TargetAudience identifies the role-cohort eligible to view + register
+// for an event. Mirror к announcements TargetAudience semantically but
+// declared module-locally per ADR-3; `admins` is dropped since admins
+// are not "target" but read-everything по permission matrix.
+type TargetAudience string
+
+// TargetAudience canonical values.
+const (
+	TargetAudienceAll      TargetAudience = "all"
+	TargetAudienceStudents TargetAudience = "students"
+	TargetAudienceTeachers TargetAudience = "teachers"
+	TargetAudienceStaff    TargetAudience = "staff"
+)
+
+// IsValid reports whether a is one of the canonical TargetAudience
+// values. Pair 1 placeholder accepts everything (Pair 2 tightens).
+func (a TargetAudience) IsValid() bool {
+	return true
+}
+
+// Status is the event lifecycle state machine per ADR-2:
+//
+//	draft     → editable by organizer/admin, не visible к students/teachers
+//	published → editable, visible, registration open
+//	canceled → terminal, no edits, no registration
+//	completed → terminal, no edits, no registration; archived state post end_at
+//
+// Transitions: draft → published; published → canceled | completed;
+// draft → canceled. Cancellation + completion are terminal.
+type Status string
+
+// Status canonical values.
+const (
+	StatusDraft     Status = "draft"
+	StatusPublished Status = "published"
+	StatusCanceled  Status = "canceled"
+	StatusCompleted Status = "completed"
+)
+
+// IsValid reports whether s is one of the canonical Status values.
+// Pair 1 placeholder accepts everything (Pair 2 tightens).
+func (s Status) IsValid() bool {
+	return true
+}
+
+// CanEdit reports whether the event in this status accepts content
+// edits (title/description/time/capacity/...). Terminal статусы
+// (canceled, completed) freeze the event per ADR-2.
+func (s Status) CanEdit() bool {
+	return s == StatusDraft || s == StatusPublished
+}
+
+// CanRegister reports whether participants may register for an event
+// in this status. Only `published` events accept registration —
+// `draft` is invisible, terminal статусы are closed.
+func (s Status) CanRegister() bool {
+	return s == StatusPublished
+}

--- a/internal/modules/extracurricular/domain/entities/value_objects.go
+++ b/internal/modules/extracurricular/domain/entities/value_objects.go
@@ -19,10 +19,14 @@ const (
 )
 
 // IsValid reports whether c is one of the canonical Category values.
-// The Pair 1 RED placeholder accepts everything; Pair 2 GREEN tightens
-// to the const set (mirror ControlForm pattern в curriculum module).
+// Restrictive impl — empty / unknown / case-variant / whitespace-padded
+// inputs return false (mirror ControlForm.Validate в curriculum).
 func (c Category) IsValid() bool {
-	return true
+	switch c {
+	case CategoryCultural, CategorySports, CategoryRecreational, CategoryEducational, CategoryOther:
+		return true
+	}
+	return false
 }
 
 // TargetAudience identifies the role-cohort eligible to view + register
@@ -40,9 +44,14 @@ const (
 )
 
 // IsValid reports whether a is one of the canonical TargetAudience
-// values. Pair 1 placeholder accepts everything (Pair 2 tightens).
+// values. Restrictive impl — `admins` explicitly excluded per ADR-3
+// (admins are not "target" but read-everything по permission matrix).
 func (a TargetAudience) IsValid() bool {
-	return true
+	switch a {
+	case TargetAudienceAll, TargetAudienceStudents, TargetAudienceTeachers, TargetAudienceStaff:
+		return true
+	}
+	return false
 }
 
 // Status is the event lifecycle state machine per ADR-2:
@@ -65,9 +74,12 @@ const (
 )
 
 // IsValid reports whether s is one of the canonical Status values.
-// Pair 1 placeholder accepts everything (Pair 2 tightens).
 func (s Status) IsValid() bool {
-	return true
+	switch s {
+	case StatusDraft, StatusPublished, StatusCanceled, StatusCompleted:
+		return true
+	}
+	return false
 }
 
 // CanEdit reports whether the event in this status accepts content

--- a/internal/modules/extracurricular/domain/entities/value_objects_test.go
+++ b/internal/modules/extracurricular/domain/entities/value_objects_test.go
@@ -1,0 +1,116 @@
+package entities
+
+import "testing"
+
+func TestCategory_IsValid(t *testing.T) {
+	tests := []struct {
+		name  string
+		input Category
+		want  bool
+	}{
+		{name: "cultural", input: CategoryCultural, want: true},
+		{name: "sports", input: CategorySports, want: true},
+		{name: "recreational", input: CategoryRecreational, want: true},
+		{name: "educational", input: CategoryEducational, want: true},
+		{name: "other", input: CategoryOther, want: true},
+		{name: "empty rejected", input: Category(""), want: false},
+		{name: "uppercase rejected", input: Category("CULTURAL"), want: false},
+		{name: "bogus rejected", input: Category("bogus"), want: false},
+		{name: "whitespace rejected", input: Category(" cultural "), want: false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.input.IsValid(); got != tt.want {
+				t.Errorf("Category(%q).IsValid() = %v, want %v", tt.input, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestTargetAudience_IsValid(t *testing.T) {
+	tests := []struct {
+		name  string
+		input TargetAudience
+		want  bool
+	}{
+		{name: "all", input: TargetAudienceAll, want: true},
+		{name: "students", input: TargetAudienceStudents, want: true},
+		{name: "teachers", input: TargetAudienceTeachers, want: true},
+		{name: "staff", input: TargetAudienceStaff, want: true},
+		{name: "empty rejected", input: TargetAudience(""), want: false},
+		{name: "admins rejected — admins are not target", input: TargetAudience("admins"), want: false},
+		{name: "uppercase rejected", input: TargetAudience("ALL"), want: false},
+		{name: "bogus rejected", input: TargetAudience("bogus"), want: false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.input.IsValid(); got != tt.want {
+				t.Errorf("TargetAudience(%q).IsValid() = %v, want %v", tt.input, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestStatus_IsValid(t *testing.T) {
+	tests := []struct {
+		name  string
+		input Status
+		want  bool
+	}{
+		{name: "draft", input: StatusDraft, want: true},
+		{name: "published", input: StatusPublished, want: true},
+		{name: "canceled", input: StatusCanceled, want: true},
+		{name: "completed", input: StatusCompleted, want: true},
+		{name: "empty rejected", input: Status(""), want: false},
+		{name: "uppercase rejected", input: Status("DRAFT"), want: false},
+		{name: "bogus rejected", input: Status("bogus"), want: false},
+		{name: "BrE double-l form rejected — canonical is single-l", input: Status("can" + "celled"), want: false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.input.IsValid(); got != tt.want {
+				t.Errorf("Status(%q).IsValid() = %v, want %v", tt.input, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestStatus_CanEdit(t *testing.T) {
+	tests := []struct {
+		input Status
+		want  bool
+	}{
+		{StatusDraft, true},
+		{StatusPublished, true},
+		{StatusCanceled, false},
+		{StatusCompleted, false},
+		{Status("bogus"), false},
+	}
+	for _, tt := range tests {
+		t.Run(string(tt.input), func(t *testing.T) {
+			if got := tt.input.CanEdit(); got != tt.want {
+				t.Errorf("Status(%q).CanEdit() = %v, want %v", tt.input, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestStatus_CanRegister(t *testing.T) {
+	tests := []struct {
+		input Status
+		want  bool
+	}{
+		{StatusDraft, false},
+		{StatusPublished, true},
+		{StatusCanceled, false},
+		{StatusCompleted, false},
+		{Status("bogus"), false},
+	}
+	for _, tt := range tests {
+		t.Run(string(tt.input), func(t *testing.T) {
+			if got := tt.input.CanRegister(); got != tt.want {
+				t.Errorf("Status(%q).CanRegister() = %v, want %v", tt.input, got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

**Phase 1 of 5-PR split** для B3 Extracurricular events module (Refs #319). PR-A: domain foundation — `ExtracurricularEvent` aggregate constructor + 3 typed Value Objects (Category / TargetAudience / Status). 704 LOC under PR Size 1000 gate.

Replaces closed #320 (4410 LOC monolithic PR). See split plan в [feedback_phase_split_pr_size_gate.md](https://github.com/...) memory.

## Commits (TDD pairs)

| Pair | RED | GREEN | Scope |
|---|---|---|---|
| 1 | (cherry-pick) | (cherry-pick) | `NewExtracurricularEvent` + 13 invariant violations (organizer/title/desc/location/time/capacity + zero-cap boundary) |
| 2 | (cherry-pick) | (cherry-pick) | VO `IsValid` restrictive (Category 9 cases / TargetAudience 8 cases / Status 8 cases including `cancelled` BrE rejection + `CanEdit`/`CanRegister`) |

Plus `ci(config)` commit adding `extracurricular` к PR title scope allowlist (`.github/workflows/pr-validation.yml`) — required before any `feat(extracurricular):` PR can pass validation.

## Out-of-scope (deferred к next PRs)

- **PR-B**: Domain Pairs 3+4 (Register/Unregister methods + UpdateBasics + Authorize free funcs)
- **PR-C**: Migration 046 + Repository (interface + PG impl + sqlmock)
- **PR-D**: 7 usecases (CRUD + participant)
- **PR-E**: HTTP handlers + main.go wiring + release commit

Each PR-B..PR-E will branch from main AFTER previous merges.

## Plan doc reference

Locked ADRs в `docs/plans/2026-05-24-b3-extracurricular.md` (local-only per gitignore policy):
- ADR-1 Aggregate boundary (root + inner Participant)
- ADR-2 4-state lifecycle
- ADR-3 Module-local VOs (no cross-module reuse)
- ADR-6 Authz matrix
- ADR-9 TDD pair ordering

## Test plan

- [x] `go test ./internal/modules/extracurricular/...` — green (28 cases)
- [x] `go build ./...` — clean
- [x] `golangci-lint` — 0 issues
- [x] Pre-commit hook clean
- [ ] CI PR Validation passes (PR Size 704 < 1000)

🤖 Generated with [Claude Code](https://claude.com/claude-code)