### PR TITLE
feat(extracurricular): v0.162.0c — migration 046 + repository (DIP + PG impl + sqlmock)

### DIFF
--- a/internal/modules/extracurricular/application/usecases/repository_interfaces.go
+++ b/internal/modules/extracurricular/application/usecases/repository_interfaces.go
@@ -1,0 +1,63 @@
+// Package usecases hosts application services + repository ports for
+// the extracurricular events module. Wide repository ports declared
+// here (NOT в domain/) per CLAUDE.md DIP gate.
+package usecases
+
+import (
+	"context"
+	"time"
+
+	"github.com/inf-sys-secretary-methodologist/inf-sys-secretary-methodist/internal/modules/extracurricular/domain/entities"
+	"github.com/inf-sys-secretary-methodologist/inf-sys-secretary-methodist/internal/modules/extracurricular/domain/repositories"
+)
+
+// EventRepository is the persistence port для ExtracurricularEvent
+// aggregates. Sentinel contract per repositories package:
+//
+//	repositories.ErrEventNotFound       — missing row
+//	repositories.ErrEventVersionConflict — stale Update
+//
+// Implementations should accept DBTX (not *sql.DB) so the same struct
+// can run в either single-connection или transactional mode (mirror
+// curriculum DBTX pattern).
+type EventRepository interface {
+	// Save inserts a new event row and writes the generated id back
+	// onto the entity. version starts at 0.
+	Save(ctx context.Context, e *entities.ExtracurricularEvent) error
+
+	// GetByID returns the event with the given id together with its
+	// participants list (eager-loaded for the aggregate's capacity +
+	// duplicate invariants to hold в Register/Unregister flows).
+	// repositories.ErrEventNotFound on missing row.
+	GetByID(ctx context.Context, id int64) (*entities.ExtracurricularEvent, error)
+
+	// Update writes the (already-mutated) event row back с optimistic
+	// lock on version. RowsAffected == 0 followed by an existence
+	// SELECT disambiguates:
+	//   row exists → repositories.ErrEventVersionConflict (HTTP 409)
+	//   row gone   → repositories.ErrEventNotFound (HTTP 404)
+	// Participants are NOT touched by Update — use AddParticipant /
+	// RemoveParticipant for inner-entity changes.
+	Update(ctx context.Context, e *entities.ExtracurricularEvent) error
+
+	// Delete removes the event row by id (participants cascade via FK
+	// ON DELETE CASCADE per migration 046). Returns
+	// repositories.ErrEventNotFound if the id did not exist.
+	Delete(ctx context.Context, id int64) error
+
+	// List returns a page of event summaries matching the filter +
+	// total count (ignoring Limit/Offset). Empty result is not an
+	// error. ParticipantCount populated via subquery — separate query
+	// per event would be N+1.
+	List(ctx context.Context, filter repositories.EventListFilter) (repositories.EventListResult, error)
+
+	// AddParticipant inserts a participant row для (eventID, userID).
+	// UNIQUE constraint violation surfaces via pgErrCode 23505 →
+	// entities.ErrParticipantExists is wrapped by usecase before
+	// reaching handler; repository wraps generic DB errors.
+	AddParticipant(ctx context.Context, eventID, userID int64, registeredAt time.Time) error
+
+	// RemoveParticipant deletes the participant row для (eventID,
+	// userID). Returns entities.ErrParticipantNotFound if no such row.
+	RemoveParticipant(ctx context.Context, eventID, userID int64) error
+}

--- a/internal/modules/extracurricular/domain/repositories/event_repository.go
+++ b/internal/modules/extracurricular/domain/repositories/event_repository.go
@@ -1,0 +1,74 @@
+// Package repositories declares sentinels + read-model DTOs for the
+// extracurricular events bounded context. Repository interfaces live в
+// internal/modules/extracurricular/application/usecases per DIP — этот
+// package keeps only domain values referenced both by usecases и
+// infrastructure без a circular import.
+package repositories
+
+import "errors"
+
+// ErrEventNotFound signals that no extracurricular_events row exists
+// for the given id. Handlers map к HTTP 404.
+var ErrEventNotFound = errors.New("extracurricular_event: not found")
+
+// ErrEventVersionConflict signals that an Update attempted to write
+// against a stale version (optimistic lock per plan ADR-5). The row
+// still exists. Handlers map к HTTP 409.
+var ErrEventVersionConflict = errors.New("extracurricular_event: version conflict")
+
+// EventListFilter narrows ListEvents query result. All fields optional;
+// zero-value means "no filter on this dimension". Result is also
+// audience-filtered after fetch via CanViewEvent for non-admin callers.
+type EventListFilter struct {
+	// Status filters by lifecycle state (e.g. only `published`).
+	// Empty string = no filter.
+	Status string
+
+	// Category filters by event classification. Empty = no filter.
+	Category string
+
+	// AudienceIn restricts по target_audience IN (...). Empty slice =
+	// no filter (admin queries). Non-admin handlers populate with the
+	// audience set visible к caller's role per ADR-6.
+	AudienceIn []string
+
+	// OrganizerID filters by event organizer. Zero = no filter.
+	OrganizerID int64
+
+	// FromDate / ToDate range filter on start_at. Zero = no bound.
+	FromDate string // ISO date YYYY-MM-DD or empty
+	ToDate   string
+
+	// Limit + Offset for pagination. Limit==0 → default (100). Offset
+	// negative → 0.
+	Limit  int
+	Offset int
+}
+
+// EventSummary is the projection returned by ListEvents — omits
+// participants slice (loaded only by GetByID) and description (loaded
+// by GetByID для detail view). ParticipantCount поднимается из
+// extracurricular_participants table via subquery.
+type EventSummary struct {
+	ID               int64
+	Title            string
+	Category         string
+	TargetAudience   string
+	Status           string
+	Location         string
+	StartAt          string // ISO 8601
+	EndAt            string
+	MaxCapacity      *int
+	OrganizerID      int64
+	ParticipantCount int
+	Version          int
+	CreatedAt        string
+	UpdatedAt        string
+}
+
+// EventListResult bundles the page slice + total count for paginated
+// queries — pagination needs both для frontend "X of Y" rendering.
+type EventListResult struct {
+	Items []EventSummary
+	Total int
+}

--- a/internal/modules/extracurricular/infrastructure/persistence/dbtx.go
+++ b/internal/modules/extracurricular/infrastructure/persistence/dbtx.go
@@ -1,0 +1,17 @@
+package persistence
+
+import (
+	"context"
+	"database/sql"
+)
+
+// DBTX is the narrow database surface needed by extracurricular
+// repository implementations — both `*sql.DB` (single-connection mode)
+// и `*sql.Tx` (transactional mode) satisfy it. Mirror к curriculum
+// DBTX pattern (v0.128.3 ADR-10) so the same Save/GetByID/Update
+// queries run против either driver mode.
+type DBTX interface {
+	ExecContext(ctx context.Context, query string, args ...any) (sql.Result, error)
+	QueryContext(ctx context.Context, query string, args ...any) (*sql.Rows, error)
+	QueryRowContext(ctx context.Context, query string, args ...any) *sql.Row
+}

--- a/internal/modules/extracurricular/infrastructure/persistence/event_repository_pg.go
+++ b/internal/modules/extracurricular/infrastructure/persistence/event_repository_pg.go
@@ -1,0 +1,381 @@
+package persistence
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/lib/pq"
+
+	"github.com/inf-sys-secretary-methodologist/inf-sys-secretary-methodist/internal/modules/extracurricular/application/usecases"
+	"github.com/inf-sys-secretary-methodologist/inf-sys-secretary-methodist/internal/modules/extracurricular/domain/entities"
+	"github.com/inf-sys-secretary-methodologist/inf-sys-secretary-methodist/internal/modules/extracurricular/domain/repositories"
+)
+
+// Compile-time assertion: PG impl satisfies the wide port в the
+// consuming application/usecases layer (DIP per CLAUDE.md gate).
+var _ usecases.EventRepository = (*EventRepositoryPG)(nil)
+
+// EventRepositoryPG persists ExtracurricularEvent aggregates against
+// the extracurricular_events + extracurricular_participants tables
+// (migration 046). Optimistic locking per plan ADR-5 — Update uses
+// WHERE id = ? AND version = ? и disambiguates RowsAffected == 0 via
+// a follow-up existence SELECT.
+type EventRepositoryPG struct {
+	db DBTX
+}
+
+// NewEventRepositoryPG constructs the repository. db may be *sql.DB
+// (default DI) или *sql.Tx (future bulk path).
+func NewEventRepositoryPG(db DBTX) *EventRepositoryPG {
+	return &EventRepositoryPG{db: db}
+}
+
+// pqUniqueViolation is the SQLSTATE code for a unique-constraint
+// violation. Mirror к curriculum's local copy — keeps the
+// extracurricular bounded context free of a cross-module dependency
+// on shared error mappers.
+const pqUniqueViolation = "23505"
+
+const eventSelectColumns = `id, title, description, category, target_audience, status,
+	location, start_at, end_at, max_capacity, organizer_id, version, created_at, updated_at`
+
+// Save inserts a new event row and writes the generated id back onto
+// the entity. Participants slice is NOT persisted here — fresh events
+// have no participants.
+func (r *EventRepositoryPG) Save(ctx context.Context, e *entities.ExtracurricularEvent) error {
+	const query = `
+		INSERT INTO extracurricular_events (
+			title, description, category, target_audience, status,
+			location, start_at, end_at, max_capacity, organizer_id,
+			version, created_at, updated_at
+		) VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13)
+		RETURNING id`
+
+	var newID int64
+	err := r.db.QueryRowContext(ctx, query,
+		e.Title(),
+		nullableText(e.Description()),
+		string(e.Category()),
+		string(e.TargetAudience()),
+		string(e.Status()),
+		nullableText(e.Location()),
+		e.StartAt(),
+		e.EndAt(),
+		nullableIntPtr(e.MaxCapacity()),
+		e.OrganizerID(),
+		e.Version(),
+		e.CreatedAt(),
+		e.UpdatedAt(),
+	).Scan(&newID)
+	if err != nil {
+		return fmt.Errorf("extracurricular: save: %w", err)
+	}
+	e.ID = newID
+	return nil
+}
+
+// GetByID returns the event together с its participants list. Two
+// queries — events row + participants slice. Returns
+// repositories.ErrEventNotFound on missing event row.
+func (r *EventRepositoryPG) GetByID(ctx context.Context, id int64) (*entities.ExtracurricularEvent, error) {
+	const query = `SELECT ` + eventSelectColumns + ` FROM extracurricular_events WHERE id = $1`
+	var (
+		idv            int64
+		title          string
+		description    sql.NullString
+		category       string
+		targetAudience string
+		status         string
+		location       sql.NullString
+		startAt        time.Time
+		endAt          time.Time
+		maxCapacity    sql.NullInt64
+		organizerID    int64
+		version        int
+		createdAt      time.Time
+		updatedAt      time.Time
+	)
+	err := r.db.QueryRowContext(ctx, query, id).Scan(
+		&idv, &title, &description, &category, &targetAudience, &status,
+		&location, &startAt, &endAt, &maxCapacity, &organizerID, &version,
+		&createdAt, &updatedAt,
+	)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return nil, repositories.ErrEventNotFound
+		}
+		return nil, fmt.Errorf("extracurricular: get by id: %w", err)
+	}
+	participants, err := r.loadParticipants(ctx, idv)
+	if err != nil {
+		return nil, err
+	}
+	var maxCapPtr *int
+	if maxCapacity.Valid {
+		v := int(maxCapacity.Int64)
+		maxCapPtr = &v
+	}
+	return entities.ReconstituteExtracurricularEvent(
+		idv, title, description.String,
+		entities.Category(category), entities.TargetAudience(targetAudience),
+		entities.Status(status),
+		location.String, startAt, endAt, maxCapPtr, organizerID,
+		participants, version, createdAt, updatedAt,
+	), nil
+}
+
+func (r *EventRepositoryPG) loadParticipants(ctx context.Context, eventID int64) ([]entities.Participant, error) {
+	const query = `SELECT user_id, registered_at FROM extracurricular_participants
+		WHERE event_id = $1 ORDER BY registered_at ASC, user_id ASC`
+	rows, err := r.db.QueryContext(ctx, query, eventID)
+	if err != nil {
+		return nil, fmt.Errorf("extracurricular: load participants: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+	var out []entities.Participant
+	for rows.Next() {
+		var userID int64
+		var registeredAt time.Time
+		if err := rows.Scan(&userID, &registeredAt); err != nil {
+			return nil, fmt.Errorf("extracurricular: scan participant: %w", err)
+		}
+		out = append(out, entities.Participant{UserID: userID, RegisteredAt: registeredAt})
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("extracurricular: iter participants: %w", err)
+	}
+	return out, nil
+}
+
+// Update writes event row back с optimistic lock (WHERE id = ? AND
+// version = ?). RowsAffected == 0 → existence probe disambiguates
+// version conflict vs vanished row.
+func (r *EventRepositoryPG) Update(ctx context.Context, e *entities.ExtracurricularEvent) error {
+	const query = `
+		UPDATE extracurricular_events SET
+			title = $1, description = $2, category = $3, target_audience = $4,
+			status = $5, location = $6, start_at = $7, end_at = $8,
+			max_capacity = $9, version = version + 1, updated_at = $10
+		WHERE id = $11 AND version = $12`
+	res, err := r.db.ExecContext(ctx, query,
+		e.Title(), nullableText(e.Description()),
+		string(e.Category()), string(e.TargetAudience()), string(e.Status()),
+		nullableText(e.Location()), e.StartAt(), e.EndAt(),
+		nullableIntPtr(e.MaxCapacity()), e.UpdatedAt(),
+		e.ID, e.Version(),
+	)
+	if err != nil {
+		return fmt.Errorf("extracurricular: update: %w", err)
+	}
+	n, err := res.RowsAffected()
+	if err != nil {
+		return fmt.Errorf("extracurricular: update: rows affected: %w", err)
+	}
+	if n == 0 {
+		return r.disambiguateAbsentUpdate(ctx, e.ID)
+	}
+	return nil
+}
+
+func (r *EventRepositoryPG) disambiguateAbsentUpdate(ctx context.Context, id int64) error {
+	const probe = `SELECT 1 FROM extracurricular_events WHERE id = $1`
+	var found int
+	err := r.db.QueryRowContext(ctx, probe, id).Scan(&found)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return repositories.ErrEventNotFound
+		}
+		return fmt.Errorf("extracurricular: disambiguate: %w", err)
+	}
+	return repositories.ErrEventVersionConflict
+}
+
+// Delete removes the event row by id. Participants cascade via FK
+// ON DELETE CASCADE per migration 046. RowsAffected == 0 →
+// ErrEventNotFound.
+func (r *EventRepositoryPG) Delete(ctx context.Context, id int64) error {
+	const query = `DELETE FROM extracurricular_events WHERE id = $1`
+	res, err := r.db.ExecContext(ctx, query, id)
+	if err != nil {
+		return fmt.Errorf("extracurricular: delete: %w", err)
+	}
+	n, err := res.RowsAffected()
+	if err != nil {
+		return fmt.Errorf("extracurricular: delete: rows affected: %w", err)
+	}
+	if n == 0 {
+		return repositories.ErrEventNotFound
+	}
+	return nil
+}
+
+// List returns a page of event summaries matching the filter + total
+// count. ParticipantCount populated via correlated subquery (no N+1).
+func (r *EventRepositoryPG) List(ctx context.Context, filter repositories.EventListFilter) (repositories.EventListResult, error) {
+	where, args := buildEventWhere(filter)
+	countQuery := `SELECT COUNT(*) FROM extracurricular_events ` + where
+	var total int
+	if err := r.db.QueryRowContext(ctx, countQuery, args...).Scan(&total); err != nil {
+		return repositories.EventListResult{}, fmt.Errorf("extracurricular: list count: %w", err)
+	}
+
+	limit := filter.Limit
+	if limit <= 0 {
+		limit = 100
+	}
+	offset := max(filter.Offset, 0)
+	args = append(args, limit, offset)
+
+	pageQuery := `SELECT id, title, category, target_audience, status, location,
+		start_at, end_at, max_capacity, organizer_id, version, created_at, updated_at,
+		(SELECT COUNT(*) FROM extracurricular_participants WHERE event_id = extracurricular_events.id) AS participant_count
+		FROM extracurricular_events ` + where +
+		fmt.Sprintf(` ORDER BY start_at ASC, id ASC LIMIT $%d OFFSET $%d`, len(args)-1, len(args))
+
+	rows, err := r.db.QueryContext(ctx, pageQuery, args...)
+	if err != nil {
+		return repositories.EventListResult{}, fmt.Errorf("extracurricular: list page: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	var items []repositories.EventSummary
+	for rows.Next() {
+		var (
+			s             repositories.EventSummary
+			location      sql.NullString
+			maxCap        sql.NullInt64
+			startAt       time.Time
+			endAt         time.Time
+			createdAt     time.Time
+			updatedAt     time.Time
+			participantCt int
+		)
+		if err := rows.Scan(&s.ID, &s.Title, &s.Category, &s.TargetAudience, &s.Status,
+			&location, &startAt, &endAt, &maxCap, &s.OrganizerID, &s.Version,
+			&createdAt, &updatedAt, &participantCt); err != nil {
+			return repositories.EventListResult{}, fmt.Errorf("extracurricular: list scan: %w", err)
+		}
+		s.Location = location.String
+		if maxCap.Valid {
+			v := int(maxCap.Int64)
+			s.MaxCapacity = &v
+		}
+		s.StartAt = startAt.Format(time.RFC3339)
+		s.EndAt = endAt.Format(time.RFC3339)
+		s.CreatedAt = createdAt.Format(time.RFC3339)
+		s.UpdatedAt = updatedAt.Format(time.RFC3339)
+		s.ParticipantCount = participantCt
+		items = append(items, s)
+	}
+	if err := rows.Err(); err != nil {
+		return repositories.EventListResult{}, fmt.Errorf("extracurricular: list iter: %w", err)
+	}
+	return repositories.EventListResult{Items: items, Total: total}, nil
+}
+
+// buildEventWhere assembles dynamic WHERE clause + arg slice from the
+// filter. Returns clause string starting with "WHERE ..." (or empty
+// if no filters) plus positional args. #nosec G201 — all clause
+// fragments are static literal strings; only user values bind via $N.
+func buildEventWhere(f repositories.EventListFilter) (string, []any) {
+	var clauses []string
+	var args []any
+	idx := 1
+	if f.Status != "" {
+		clauses = append(clauses, fmt.Sprintf("status = $%d", idx))
+		args = append(args, f.Status)
+		idx++
+	}
+	if f.Category != "" {
+		clauses = append(clauses, fmt.Sprintf("category = $%d", idx))
+		args = append(args, f.Category)
+		idx++
+	}
+	if len(f.AudienceIn) > 0 {
+		clauses = append(clauses, fmt.Sprintf("target_audience = ANY($%d)", idx))
+		args = append(args, pq.Array(f.AudienceIn))
+		idx++
+	}
+	if f.OrganizerID > 0 {
+		clauses = append(clauses, fmt.Sprintf("organizer_id = $%d", idx))
+		args = append(args, f.OrganizerID)
+		idx++
+	}
+	if f.FromDate != "" {
+		clauses = append(clauses, fmt.Sprintf("start_at >= $%d", idx))
+		args = append(args, f.FromDate)
+		idx++
+	}
+	if f.ToDate != "" {
+		clauses = append(clauses, fmt.Sprintf("start_at <= $%d", idx))
+		args = append(args, f.ToDate)
+	}
+	if len(clauses) == 0 {
+		return "", args
+	}
+	return "WHERE " + strings.Join(clauses, " AND "), args
+}
+
+// AddParticipant inserts a (event_id, user_id) row. UNIQUE constraint
+// violation maps to entities.ErrParticipantExists.
+func (r *EventRepositoryPG) AddParticipant(ctx context.Context, eventID, userID int64, registeredAt time.Time) error {
+	const query = `INSERT INTO extracurricular_participants (event_id, user_id, registered_at)
+		VALUES ($1, $2, $3)`
+	_, err := r.db.ExecContext(ctx, query, eventID, userID, registeredAt)
+	if err != nil {
+		if isUniqueViolation(err) {
+			return entities.ErrParticipantExists
+		}
+		return fmt.Errorf("extracurricular: add participant: %w", err)
+	}
+	return nil
+}
+
+// RemoveParticipant deletes the (event_id, user_id) row. 0 rows →
+// entities.ErrParticipantNotFound.
+func (r *EventRepositoryPG) RemoveParticipant(ctx context.Context, eventID, userID int64) error {
+	const query = `DELETE FROM extracurricular_participants WHERE event_id = $1 AND user_id = $2`
+	res, err := r.db.ExecContext(ctx, query, eventID, userID)
+	if err != nil {
+		return fmt.Errorf("extracurricular: remove participant: %w", err)
+	}
+	n, err := res.RowsAffected()
+	if err != nil {
+		return fmt.Errorf("extracurricular: remove participant: rows affected: %w", err)
+	}
+	if n == 0 {
+		return entities.ErrParticipantNotFound
+	}
+	return nil
+}
+
+// nullableText maps empty Go string to SQL NULL so the description /
+// location columns stay NULL (the migration leaves both nullable).
+func nullableText(s string) sql.NullString {
+	if s == "" {
+		return sql.NullString{}
+	}
+	return sql.NullString{String: s, Valid: true}
+}
+
+// nullableIntPtr maps *int → sql.NullInt64 — nil = NULL.
+func nullableIntPtr(p *int) sql.NullInt64 {
+	if p == nil {
+		return sql.NullInt64{}
+	}
+	return sql.NullInt64{Int64: int64(*p), Valid: true}
+}
+
+// isUniqueViolation reports whether err is a PostgreSQL unique
+// violation (SQLSTATE 23505).
+func isUniqueViolation(err error) bool {
+	var pqErr *pq.Error
+	if errors.As(err, &pqErr) {
+		return pqErr.Code == pqUniqueViolation
+	}
+	return false
+}

--- a/internal/modules/extracurricular/infrastructure/persistence/event_repository_pg_test.go
+++ b/internal/modules/extracurricular/infrastructure/persistence/event_repository_pg_test.go
@@ -1,0 +1,320 @@
+package persistence
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"regexp"
+	"testing"
+	"time"
+
+	"github.com/DATA-DOG/go-sqlmock"
+	"github.com/lib/pq"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/inf-sys-secretary-methodologist/inf-sys-secretary-methodist/internal/modules/extracurricular/domain/entities"
+	"github.com/inf-sys-secretary-methodologist/inf-sys-secretary-methodist/internal/modules/extracurricular/domain/repositories"
+)
+
+func newEventRepoMock(t *testing.T) (*EventRepositoryPG, sqlmock.Sqlmock) {
+	t.Helper()
+	db, mock, err := sqlmock.New()
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = db.Close() })
+	return NewEventRepositoryPG(db), mock
+}
+
+func freshEvent(t *testing.T) *entities.ExtracurricularEvent {
+	t.Helper()
+	now := time.Date(2026, 5, 24, 12, 0, 0, 0, time.UTC)
+	e, err := entities.NewExtracurricularEvent(entities.NewExtracurricularEventParams{
+		Title:          "Концерт",
+		Description:    "desc",
+		Category:       entities.CategoryCultural,
+		TargetAudience: entities.TargetAudienceAll,
+		Location:       "Актовый зал",
+		StartAt:        now.Add(48 * time.Hour),
+		EndAt:          now.Add(50 * time.Hour),
+		OrganizerID:    42,
+		Now:            now,
+	})
+	require.NoError(t, err)
+	return e
+}
+
+// ===== Save =====
+
+func TestEventRepoPG_Save_HappyPath(t *testing.T) {
+	repo, mock := newEventRepoMock(t)
+	e := freshEvent(t)
+
+	mock.ExpectQuery(regexp.QuoteMeta("INSERT INTO extracurricular_events")).
+		WithArgs("Концерт", sql.NullString{String: "desc", Valid: true},
+			"cultural", "all", "draft",
+			sql.NullString{String: "Актовый зал", Valid: true},
+			e.StartAt(), e.EndAt(), sql.NullInt64{},
+			int64(42), 0, e.CreatedAt(), e.UpdatedAt()).
+		WillReturnRows(sqlmock.NewRows([]string{"id"}).AddRow(int64(99)))
+
+	err := repo.Save(context.Background(), e)
+	require.NoError(t, err)
+	assert.Equal(t, int64(99), e.ID, "Save must populate generated id")
+	assert.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestEventRepoPG_Save_NullableFields(t *testing.T) {
+	repo, mock := newEventRepoMock(t)
+	now := time.Date(2026, 5, 24, 12, 0, 0, 0, time.UTC)
+	e, err := entities.NewExtracurricularEvent(entities.NewExtracurricularEventParams{
+		Title:          "minimal",
+		Description:    "",
+		Category:       entities.CategorySports,
+		TargetAudience: entities.TargetAudienceStudents,
+		Location:       "",
+		StartAt:        now.Add(48 * time.Hour),
+		EndAt:          now.Add(50 * time.Hour),
+		MaxCapacity:    nil,
+		OrganizerID:    7,
+		Now:            now,
+	})
+	require.NoError(t, err)
+
+	mock.ExpectQuery(regexp.QuoteMeta("INSERT INTO extracurricular_events")).
+		WithArgs("minimal", sql.NullString{}, "sports", "students", "draft",
+			sql.NullString{}, e.StartAt(), e.EndAt(), sql.NullInt64{},
+			int64(7), 0, e.CreatedAt(), e.UpdatedAt()).
+		WillReturnRows(sqlmock.NewRows([]string{"id"}).AddRow(int64(100)))
+
+	err = repo.Save(context.Background(), e)
+	require.NoError(t, err)
+	assert.NoError(t, mock.ExpectationsWereMet())
+}
+
+// ===== GetByID =====
+
+func TestEventRepoPG_GetByID_HappyPathWithParticipants(t *testing.T) {
+	repo, mock := newEventRepoMock(t)
+	now := time.Date(2026, 5, 24, 12, 0, 0, 0, time.UTC)
+
+	mock.ExpectQuery(regexp.QuoteMeta("SELECT id, title, description, category, target_audience, status")).
+		WithArgs(int64(99)).
+		WillReturnRows(sqlmock.NewRows([]string{
+			"id", "title", "description", "category", "target_audience", "status",
+			"location", "start_at", "end_at", "max_capacity", "organizer_id",
+			"version", "created_at", "updated_at",
+		}).AddRow(int64(99), "Концерт", sql.NullString{String: "desc", Valid: true},
+			"cultural", "all", "published",
+			sql.NullString{String: "loc", Valid: true},
+			now, now.Add(2*time.Hour), sql.NullInt64{Int64: 50, Valid: true},
+			int64(42), 1, now, now))
+
+	mock.ExpectQuery(regexp.QuoteMeta("SELECT user_id, registered_at FROM extracurricular_participants")).
+		WithArgs(int64(99)).
+		WillReturnRows(sqlmock.NewRows([]string{"user_id", "registered_at"}).
+			AddRow(int64(101), now).
+			AddRow(int64(102), now.Add(time.Minute)))
+
+	e, err := repo.GetByID(context.Background(), 99)
+	require.NoError(t, err)
+	require.NotNil(t, e)
+	assert.Equal(t, int64(99), e.ID)
+	assert.Equal(t, "Концерт", e.Title())
+	assert.Equal(t, entities.CategoryCultural, e.Category())
+	assert.Equal(t, entities.StatusPublished, e.Status())
+	require.NotNil(t, e.MaxCapacity())
+	assert.Equal(t, 50, *e.MaxCapacity())
+	parts := e.Participants()
+	require.Len(t, parts, 2)
+	assert.Equal(t, int64(101), parts[0].UserID)
+	assert.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestEventRepoPG_GetByID_NotFound(t *testing.T) {
+	repo, mock := newEventRepoMock(t)
+	mock.ExpectQuery(regexp.QuoteMeta("FROM extracurricular_events WHERE id = $1")).
+		WithArgs(int64(404)).
+		WillReturnError(sql.ErrNoRows)
+
+	e, err := repo.GetByID(context.Background(), 404)
+	assert.Nil(t, e)
+	assert.True(t, errors.Is(err, repositories.ErrEventNotFound), "want ErrEventNotFound, got %v", err)
+	assert.NoError(t, mock.ExpectationsWereMet())
+}
+
+// ===== Update =====
+
+func TestEventRepoPG_Update_HappyPath(t *testing.T) {
+	repo, mock := newEventRepoMock(t)
+	e := freshEvent(t)
+	e.ID = 99
+	mock.ExpectExec(regexp.QuoteMeta("UPDATE extracurricular_events SET")).
+		WithArgs("Концерт", sql.NullString{String: "desc", Valid: true},
+			"cultural", "all", "draft",
+			sql.NullString{String: "Актовый зал", Valid: true},
+			e.StartAt(), e.EndAt(), sql.NullInt64{},
+			e.UpdatedAt(), int64(99), 0).
+		WillReturnResult(sqlmock.NewResult(0, 1))
+
+	err := repo.Update(context.Background(), e)
+	require.NoError(t, err)
+	assert.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestEventRepoPG_Update_VersionConflict(t *testing.T) {
+	repo, mock := newEventRepoMock(t)
+	e := freshEvent(t)
+	e.ID = 99
+	mock.ExpectExec(regexp.QuoteMeta("UPDATE extracurricular_events SET")).
+		WillReturnResult(sqlmock.NewResult(0, 0))
+	mock.ExpectQuery(regexp.QuoteMeta("SELECT 1 FROM extracurricular_events WHERE id")).
+		WithArgs(int64(99)).
+		WillReturnRows(sqlmock.NewRows([]string{"?column?"}).AddRow(1))
+
+	err := repo.Update(context.Background(), e)
+	assert.True(t, errors.Is(err, repositories.ErrEventVersionConflict), "want ErrEventVersionConflict, got %v", err)
+	assert.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestEventRepoPG_Update_VanishedRow(t *testing.T) {
+	repo, mock := newEventRepoMock(t)
+	e := freshEvent(t)
+	e.ID = 99
+	mock.ExpectExec(regexp.QuoteMeta("UPDATE extracurricular_events SET")).
+		WillReturnResult(sqlmock.NewResult(0, 0))
+	mock.ExpectQuery(regexp.QuoteMeta("SELECT 1 FROM extracurricular_events WHERE id")).
+		WithArgs(int64(99)).
+		WillReturnError(sql.ErrNoRows)
+
+	err := repo.Update(context.Background(), e)
+	assert.True(t, errors.Is(err, repositories.ErrEventNotFound), "want ErrEventNotFound after vanished row, got %v", err)
+	assert.NoError(t, mock.ExpectationsWereMet())
+}
+
+// ===== Delete =====
+
+func TestEventRepoPG_Delete_HappyPath(t *testing.T) {
+	repo, mock := newEventRepoMock(t)
+	mock.ExpectExec(regexp.QuoteMeta("DELETE FROM extracurricular_events WHERE id = $1")).
+		WithArgs(int64(99)).
+		WillReturnResult(sqlmock.NewResult(0, 1))
+
+	require.NoError(t, repo.Delete(context.Background(), 99))
+	assert.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestEventRepoPG_Delete_NotFound(t *testing.T) {
+	repo, mock := newEventRepoMock(t)
+	mock.ExpectExec(regexp.QuoteMeta("DELETE FROM extracurricular_events WHERE id = $1")).
+		WithArgs(int64(404)).
+		WillReturnResult(sqlmock.NewResult(0, 0))
+
+	err := repo.Delete(context.Background(), 404)
+	assert.True(t, errors.Is(err, repositories.ErrEventNotFound))
+	assert.NoError(t, mock.ExpectationsWereMet())
+}
+
+// ===== List =====
+
+func TestEventRepoPG_List_FilterByStatusAndAudience(t *testing.T) {
+	repo, mock := newEventRepoMock(t)
+	now := time.Date(2026, 5, 24, 12, 0, 0, 0, time.UTC)
+
+	mock.ExpectQuery(regexp.QuoteMeta("SELECT COUNT(*) FROM extracurricular_events WHERE status = $1 AND target_audience = ANY($2)")).
+		WithArgs("published", pq.Array([]string{"all", "students"})).
+		WillReturnRows(sqlmock.NewRows([]string{"count"}).AddRow(2))
+
+	mock.ExpectQuery(regexp.QuoteMeta("WHERE status = $1 AND target_audience = ANY($2)")).
+		WithArgs("published", pq.Array([]string{"all", "students"}), 50, 0).
+		WillReturnRows(sqlmock.NewRows([]string{
+			"id", "title", "category", "target_audience", "status", "location",
+			"start_at", "end_at", "max_capacity", "organizer_id", "version",
+			"created_at", "updated_at", "participant_count",
+		}).AddRow(int64(1), "Event 1", "cultural", "all", "published",
+			sql.NullString{}, now, now.Add(time.Hour), sql.NullInt64{},
+			int64(42), 0, now, now, 3))
+
+	result, err := repo.List(context.Background(), repositories.EventListFilter{
+		Status:     "published",
+		AudienceIn: []string{"all", "students"},
+		Limit:      50,
+	})
+	require.NoError(t, err)
+	assert.Equal(t, 2, result.Total)
+	require.Len(t, result.Items, 1)
+	assert.Equal(t, int64(1), result.Items[0].ID)
+	assert.Equal(t, 3, result.Items[0].ParticipantCount)
+	assert.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestEventRepoPG_List_DefaultLimitWhenZero(t *testing.T) {
+	repo, mock := newEventRepoMock(t)
+
+	mock.ExpectQuery(regexp.QuoteMeta("SELECT COUNT(*) FROM extracurricular_events")).
+		WillReturnRows(sqlmock.NewRows([]string{"count"}).AddRow(0))
+
+	mock.ExpectQuery(regexp.QuoteMeta("FROM extracurricular_events")).
+		WithArgs(100, 0). // default limit=100
+		WillReturnRows(sqlmock.NewRows([]string{
+			"id", "title", "category", "target_audience", "status", "location",
+			"start_at", "end_at", "max_capacity", "organizer_id", "version",
+			"created_at", "updated_at", "participant_count",
+		}))
+
+	result, err := repo.List(context.Background(), repositories.EventListFilter{})
+	require.NoError(t, err)
+	assert.Equal(t, 0, result.Total)
+	assert.Empty(t, result.Items)
+	assert.NoError(t, mock.ExpectationsWereMet())
+}
+
+// ===== AddParticipant =====
+
+func TestEventRepoPG_AddParticipant_HappyPath(t *testing.T) {
+	repo, mock := newEventRepoMock(t)
+	at := time.Now()
+	mock.ExpectExec(regexp.QuoteMeta("INSERT INTO extracurricular_participants")).
+		WithArgs(int64(99), int64(101), at).
+		WillReturnResult(sqlmock.NewResult(1, 1))
+
+	require.NoError(t, repo.AddParticipant(context.Background(), 99, 101, at))
+	assert.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestEventRepoPG_AddParticipant_UniqueViolation(t *testing.T) {
+	// SQLSTATE 23505 → entities.ErrParticipantExists (domain sentinel
+	// re-used by usecase для 409 mapping без re-translation).
+	repo, mock := newEventRepoMock(t)
+	at := time.Now()
+	mock.ExpectExec(regexp.QuoteMeta("INSERT INTO extracurricular_participants")).
+		WithArgs(int64(99), int64(101), at).
+		WillReturnError(&pq.Error{Code: "23505"})
+
+	err := repo.AddParticipant(context.Background(), 99, 101, at)
+	assert.True(t, errors.Is(err, entities.ErrParticipantExists),
+		"want ErrParticipantExists on unique violation, got %v", err)
+	assert.NoError(t, mock.ExpectationsWereMet())
+}
+
+// ===== RemoveParticipant =====
+
+func TestEventRepoPG_RemoveParticipant_HappyPath(t *testing.T) {
+	repo, mock := newEventRepoMock(t)
+	mock.ExpectExec(regexp.QuoteMeta("DELETE FROM extracurricular_participants WHERE event_id = $1 AND user_id = $2")).
+		WithArgs(int64(99), int64(101)).
+		WillReturnResult(sqlmock.NewResult(0, 1))
+
+	require.NoError(t, repo.RemoveParticipant(context.Background(), 99, 101))
+	assert.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestEventRepoPG_RemoveParticipant_NotFound(t *testing.T) {
+	repo, mock := newEventRepoMock(t)
+	mock.ExpectExec(regexp.QuoteMeta("DELETE FROM extracurricular_participants")).
+		WithArgs(int64(99), int64(404)).
+		WillReturnResult(sqlmock.NewResult(0, 0))
+
+	err := repo.RemoveParticipant(context.Background(), 99, 404)
+	assert.True(t, errors.Is(err, entities.ErrParticipantNotFound))
+	assert.NoError(t, mock.ExpectationsWereMet())
+}

--- a/migrations/046_create_extracurricular_events.down.sql
+++ b/migrations/046_create_extracurricular_events.down.sql
@@ -1,0 +1,4 @@
+-- Rollback v0.162.0 #319 — drop extracurricular events module schema.
+-- Participants first due к FK к events table.
+DROP TABLE IF EXISTS extracurricular_participants;
+DROP TABLE IF EXISTS extracurricular_events;

--- a/migrations/046_create_extracurricular_events.up.sql
+++ b/migrations/046_create_extracurricular_events.up.sql
@@ -1,0 +1,77 @@
+-- ============================================================================
+-- EXTRACURRICULAR EVENTS — B3 greenfield bounded context (v0.162.0)
+-- ============================================================================
+-- ADR-1 (plan docs/plans/2026-05-24-b3-extracurricular.md):
+--   ExtracurricularEvent — aggregate root; Participant — inner entity in
+--   separate table (extracurricular_participants) with FK back. Capacity
+--   invariant `len(participants) <= max_capacity` enforced в domain;
+--   CHECK constraints in this migration provide defense-in-depth.
+--
+-- ADR-4 (schema): see plan doc.
+-- ADR-5 (optimistic locking): version column on events table.
+-- ============================================================================
+
+CREATE TABLE IF NOT EXISTS extracurricular_events (
+    id              BIGSERIAL PRIMARY KEY,
+    title           VARCHAR(255) NOT NULL,
+    description     TEXT,
+    category        VARCHAR(32)  NOT NULL,
+    target_audience VARCHAR(32)  NOT NULL,
+    status          VARCHAR(32)  NOT NULL DEFAULT 'draft',
+    location        VARCHAR(255),
+    start_at        TIMESTAMPTZ  NOT NULL,
+    end_at          TIMESTAMPTZ  NOT NULL,
+    max_capacity    INT,
+    organizer_id    BIGINT       NOT NULL REFERENCES users(id) ON DELETE RESTRICT,
+    version         INT          NOT NULL DEFAULT 0,
+    created_at      TIMESTAMPTZ  NOT NULL DEFAULT NOW(),
+    updated_at      TIMESTAMPTZ  NOT NULL DEFAULT NOW(),
+    CONSTRAINT chk_extracurricular_title_nonempty
+        CHECK (length(trim(title)) > 0),
+    CONSTRAINT chk_extracurricular_description_length
+        CHECK (description IS NULL OR length(description) <= 4096),
+    CONSTRAINT chk_extracurricular_location_length
+        CHECK (location IS NULL OR length(location) <= 255),
+    CONSTRAINT chk_extracurricular_category
+        CHECK (category IN ('cultural','sports','recreational','educational','other')),
+    CONSTRAINT chk_extracurricular_audience
+        CHECK (target_audience IN ('all','students','teachers','staff')),
+    CONSTRAINT chk_extracurricular_status
+        CHECK (status IN ('draft','published','canceled','completed')),
+    CONSTRAINT chk_extracurricular_time_order
+        CHECK (start_at < end_at),
+    CONSTRAINT chk_extracurricular_capacity_nonneg
+        CHECK (max_capacity IS NULL OR max_capacity >= 0),
+    CONSTRAINT chk_extracurricular_version_nonneg
+        CHECK (version >= 0)
+);
+
+CREATE INDEX IF NOT EXISTS idx_extracurricular_events_organizer_id
+    ON extracurricular_events (organizer_id);
+CREATE INDEX IF NOT EXISTS idx_extracurricular_events_status_start_at
+    ON extracurricular_events (status, start_at);
+CREATE INDEX IF NOT EXISTS idx_extracurricular_events_target_audience
+    ON extracurricular_events (target_audience);
+
+COMMENT ON COLUMN extracurricular_events.version IS
+    'Optimistic-locking version (v0.162.0 #319) — repository UPDATE uses WHERE id = ? AND version = ?, increments on success per ADR-5';
+
+COMMENT ON COLUMN extracurricular_events.max_capacity IS
+    'NULL = unlimited; 0 = view-only event (no registration); positive = participant cap';
+
+CREATE TABLE IF NOT EXISTS extracurricular_participants (
+    id            BIGSERIAL PRIMARY KEY,
+    event_id      BIGINT NOT NULL REFERENCES extracurricular_events(id) ON DELETE CASCADE,
+    user_id       BIGINT NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    registered_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    CONSTRAINT uq_extracurricular_participants_event_user
+        UNIQUE (event_id, user_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_extracurricular_participants_event_id
+    ON extracurricular_participants (event_id);
+CREATE INDEX IF NOT EXISTS idx_extracurricular_participants_user_id
+    ON extracurricular_participants (user_id);
+
+COMMENT ON TABLE extracurricular_participants IS
+    'Inner entity of the ExtracurricularEvent aggregate (B3 v0.162.0 #319) — registration rows. UNIQUE (event_id, user_id) pins the domain invariant "no double-registration"';


### PR DESCRIPTION
## Summary

**Phase 3 of 5-PR split** для B3 Extracurricular events module (Refs #319, follows #322). PR-C: schema + persistence layer. **936 LOC** under PR Size 1000 gate.

## Commits

- `a5725d48` — Migration 046: `extracurricular_events` + `extracurricular_participants` tables. CHECK constraints mirror domain invariants (status/category/audience enums + start<end + capacity≥0 + version≥0); UNIQUE (event_id, user_id) pins "no double-registration"; indexes on organizer / status+start_at / target_audience.
- `80c7d0d1` — Repository: interface в `application/usecases/repository_interfaces.go` (DIP per CLAUDE.md) + sentinels/DTOs в `domain/repositories/event_repository.go` + PG impl с optimistic-lock disambiguate + 15 sqlmock tests.

## What lands

- **Migration 046** (events + participants schema, FK ON DELETE CASCADE для participants, ON DELETE RESTRICT для events.organizer_id).
- **`EventRepository` port** (DIP): Save / GetByID (2-query eager load participants) / Update (optimistic lock) / Delete (cascade) / List (dynamic WHERE + correlated subquery for ParticipantCount, no N+1) / AddParticipant (SQLSTATE 23505 → ErrParticipantExists) / RemoveParticipant.
- **DBTX** narrow surface mirror к curriculum pattern (accepts *sql.DB OR *sql.Tx).
- **Compile-time assertion** `var _ usecases.EventRepository = (*EventRepositoryPG)(nil)` catches signature drift at impl site.
- **15 sqlmock tests с WithArgs** per `feedback_sqlmock_withargs_for_mutation_resistance`.

## Out-of-scope (deferred к next PRs)

- **PR-D**: 7 usecases (CRUD + participant)
- **PR-E**: HTTP handlers + main.go wiring + release commit v0.162.0

## Test plan

- [x] `go test ./internal/modules/extracurricular/...` — green
- [x] `go build ./...` — clean
- [x] `golangci-lint` — 0 issues
- [x] Pre-commit hook clean
- [ ] CI passes (PR Size 936 < 1000)

🤖 Generated with [Claude Code](https://claude.com/claude-code)