### PR TITLE
feat(extracurricular): v0.162.0d — 7 usecases (CRUD + Register/Unregister)

### DIFF
--- a/internal/modules/extracurricular/application/usecases/audit_sink.go
+++ b/internal/modules/extracurricular/application/usecases/audit_sink.go
@@ -1,0 +1,53 @@
+package usecases
+
+import "context"
+
+// AuditSink is the narrow port the extracurricular use cases use to
+// emit audit events. *logging.AuditLogger satisfies it structurally —
+// no concrete dependency leaks into the use-case package per CLAUDE.md
+// Clean Architecture gate.
+type AuditSink interface {
+	LogAuditEvent(ctx context.Context, action, resource string, fields map[string]any)
+}
+
+// auditResource is the canonical resource string for every event in
+// the extracurricular bounded context.
+const auditResource = "extracurricular_event"
+
+// Pair 5 RED anchor — keeps helpers referenced until GREEN switches
+// stubs к real call sites. Removed in GREEN.
+//
+//nolint:gochecknoglobals,unused // anchor only
+var _ = []any{auditResource, emitAudit, actionFields, denialFields}
+
+// emitAudit dispatches an audit event. Nil sink → no-op so each
+// use-case site stays free of `if uc.audit != nil` clutter.
+func emitAudit(sink AuditSink, ctx context.Context, action string, fields map[string]any) {
+	if sink == nil {
+		return
+	}
+	sink.LogAuditEvent(ctx, action, auditResource, fields)
+}
+
+// actionFields returns the canonical happy-path field shape for
+// successful actions. event_id may be 0 on initial Create — the
+// fresh-row id is populated post-Save.
+func actionFields(actorID, eventID int64) map[string]any {
+	return map[string]any{
+		"actor_user_id": actorID,
+		"event_id":      eventID,
+	}
+}
+
+// denialFields composes the canonical denial-record shape. Code is a
+// machine-readable category (e.g. "not_found", "forbidden",
+// "version_conflict", "invalid") matched in the *_denied test
+// assertions so renames surface immediately.
+func denialFields(actorID, eventID int64, reason, code string) map[string]any {
+	return map[string]any{
+		"actor_user_id": actorID,
+		"event_id":      eventID,
+		"reason":        reason,
+		"code":          code,
+	}
+}

--- a/internal/modules/extracurricular/application/usecases/audit_sink.go
+++ b/internal/modules/extracurricular/application/usecases/audit_sink.go
@@ -14,12 +14,6 @@ type AuditSink interface {
 // the extracurricular bounded context.
 const auditResource = "extracurricular_event"
 
-// Pair 5 RED anchor — keeps helpers referenced until GREEN switches
-// stubs к real call sites. Removed in GREEN.
-//
-//nolint:gochecknoglobals,unused // anchor only
-var _ = []any{auditResource, emitAudit, actionFields, denialFields}
-
 // emitAudit dispatches an audit event. Nil sink → no-op so each
 // use-case site stays free of `if uc.audit != nil` clutter.
 func emitAudit(sink AuditSink, ctx context.Context, action string, fields map[string]any) {

--- a/internal/modules/extracurricular/application/usecases/create_event_usecase.go
+++ b/internal/modules/extracurricular/application/usecases/create_event_usecase.go
@@ -20,20 +20,19 @@ type CreateEventInput struct {
 	MaxCapacity    *int
 }
 
-// createEventRepo is the narrow port — CreateEvent only needs Save.
 type createEventRepo interface {
 	Save(ctx context.Context, e *entities.ExtracurricularEvent) error
 }
 
-// CreateEventUseCase persists a fresh event after authorization.
+// CreateEventUseCase persists a fresh event after authorization
+// against the actor's role.
 type CreateEventUseCase struct {
 	repo  createEventRepo
 	audit AuditSink
 	clock func() time.Time
 }
 
-// NewCreateEventUseCase wires the use case. Nil repo panics so
-// misconfiguration surfaces at DI time, not on first request.
+// NewCreateEventUseCase wires the use case.
 func NewCreateEventUseCase(repo createEventRepo, audit AuditSink, clock func() time.Time) *CreateEventUseCase {
 	if repo == nil {
 		panic("extracurricular: NewCreateEventUseCase requires non-nil repo")
@@ -44,18 +43,40 @@ func NewCreateEventUseCase(repo createEventRepo, audit AuditSink, clock func() t
 	return &CreateEventUseCase{repo: repo, audit: audit, clock: clock}
 }
 
-// Execute runs the use case:
-//  1. AuthorizeEventCreate (role gate; out-of-context → 'forbidden' denial)
-//  2. NewExtracurricularEvent (invariant gate; ErrInvalidEvent → 'invalid')
-//  3. repo.Save
-//  4. audit "extracurricular.event_created" on success
+// Execute runs the use case end-to-end:
 //
-// Pair 5 RED stub returns runtime error until GREEN impl.
+//  1. AuthorizeEventCreate (role gate)
+//  2. NewExtracurricularEvent (invariant gate)
+//  3. repo.Save
+//  4. emit extracurricular.event_created audit
 func (uc *CreateEventUseCase) Execute(ctx context.Context, actorID int64, actorRole string, isAdmin bool, in CreateEventInput) (*entities.ExtracurricularEvent, error) {
-	_ = actorID
-	_ = actorRole
-	_ = isAdmin
-	_ = in
-	_ = ctx
-	return nil, errors.New("not implemented (Pair 5 RED stub)")
+	if err := entities.AuthorizeEventCreate(actorRole, isAdmin); err != nil {
+		emitAudit(uc.audit, ctx, "extracurricular.event_create_denied",
+			denialFields(actorID, 0, "role not allowed", "forbidden"))
+		return nil, err
+	}
+	e, err := entities.NewExtracurricularEvent(entities.NewExtracurricularEventParams{
+		Title:          in.Title,
+		Description:    in.Description,
+		Category:       in.Category,
+		TargetAudience: in.TargetAudience,
+		Location:       in.Location,
+		StartAt:        in.StartAt,
+		EndAt:          in.EndAt,
+		MaxCapacity:    in.MaxCapacity,
+		OrganizerID:    actorID,
+		Now:            uc.clock(),
+	})
+	if err != nil {
+		if errors.Is(err, entities.ErrInvalidEvent) {
+			emitAudit(uc.audit, ctx, "extracurricular.event_create_denied",
+				denialFields(actorID, 0, err.Error(), "invalid"))
+		}
+		return nil, err
+	}
+	if err := uc.repo.Save(ctx, e); err != nil {
+		return nil, err
+	}
+	emitAudit(uc.audit, ctx, "extracurricular.event_created", actionFields(actorID, e.ID))
+	return e, nil
 }

--- a/internal/modules/extracurricular/application/usecases/create_event_usecase.go
+++ b/internal/modules/extracurricular/application/usecases/create_event_usecase.go
@@ -1,0 +1,61 @@
+package usecases
+
+import (
+	"context"
+	"errors"
+	"time"
+
+	"github.com/inf-sys-secretary-methodologist/inf-sys-secretary-methodist/internal/modules/extracurricular/domain/entities"
+)
+
+// CreateEventInput is the public DTO for CreateEvent.
+type CreateEventInput struct {
+	Title          string
+	Description    string
+	Category       entities.Category
+	TargetAudience entities.TargetAudience
+	Location       string
+	StartAt        time.Time
+	EndAt          time.Time
+	MaxCapacity    *int
+}
+
+// createEventRepo is the narrow port — CreateEvent only needs Save.
+type createEventRepo interface {
+	Save(ctx context.Context, e *entities.ExtracurricularEvent) error
+}
+
+// CreateEventUseCase persists a fresh event after authorization.
+type CreateEventUseCase struct {
+	repo  createEventRepo
+	audit AuditSink
+	clock func() time.Time
+}
+
+// NewCreateEventUseCase wires the use case. Nil repo panics so
+// misconfiguration surfaces at DI time, not on first request.
+func NewCreateEventUseCase(repo createEventRepo, audit AuditSink, clock func() time.Time) *CreateEventUseCase {
+	if repo == nil {
+		panic("extracurricular: NewCreateEventUseCase requires non-nil repo")
+	}
+	if clock == nil {
+		clock = time.Now
+	}
+	return &CreateEventUseCase{repo: repo, audit: audit, clock: clock}
+}
+
+// Execute runs the use case:
+//  1. AuthorizeEventCreate (role gate; out-of-context → 'forbidden' denial)
+//  2. NewExtracurricularEvent (invariant gate; ErrInvalidEvent → 'invalid')
+//  3. repo.Save
+//  4. audit "extracurricular.event_created" on success
+//
+// Pair 5 RED stub returns runtime error until GREEN impl.
+func (uc *CreateEventUseCase) Execute(ctx context.Context, actorID int64, actorRole string, isAdmin bool, in CreateEventInput) (*entities.ExtracurricularEvent, error) {
+	_ = actorID
+	_ = actorRole
+	_ = isAdmin
+	_ = in
+	_ = ctx
+	return nil, errors.New("not implemented (Pair 5 RED stub)")
+}

--- a/internal/modules/extracurricular/application/usecases/delete_event_usecase.go
+++ b/internal/modules/extracurricular/application/usecases/delete_event_usecase.go
@@ -2,7 +2,6 @@ package usecases
 
 import (
 	"context"
-	"errors"
 
 	"github.com/inf-sys-secretary-methodologist/inf-sys-secretary-methodist/internal/modules/extracurricular/domain/entities"
 )
@@ -27,12 +26,20 @@ func NewDeleteEventUseCase(repo deleteEventRepo, audit AuditSink) *DeleteEventUs
 	return &DeleteEventUseCase{repo: repo, audit: audit}
 }
 
-// Execute deletes the event after loading it for authz check. Pair 5 RED stub.
+// Execute loads + authz + deletes.
 func (uc *DeleteEventUseCase) Execute(ctx context.Context, actorID int64, actorRole string, isAdmin bool, eventID int64) error {
-	_ = actorID
-	_ = actorRole
-	_ = isAdmin
-	_ = eventID
-	_ = ctx
-	return errors.New("not implemented (Pair 5 RED stub)")
+	e, err := uc.repo.GetByID(ctx, eventID)
+	if err != nil {
+		return err
+	}
+	if err := entities.AuthorizeEventEdit(actorID, e.OrganizerID(), actorRole, isAdmin); err != nil {
+		emitAudit(uc.audit, ctx, "extracurricular.event_delete_denied",
+			denialFields(actorID, eventID, "not organizer / not admin", "forbidden"))
+		return err
+	}
+	if err := uc.repo.Delete(ctx, eventID); err != nil {
+		return err
+	}
+	emitAudit(uc.audit, ctx, "extracurricular.event_deleted", actionFields(actorID, eventID))
+	return nil
 }

--- a/internal/modules/extracurricular/application/usecases/delete_event_usecase.go
+++ b/internal/modules/extracurricular/application/usecases/delete_event_usecase.go
@@ -1,0 +1,38 @@
+package usecases
+
+import (
+	"context"
+	"errors"
+
+	"github.com/inf-sys-secretary-methodologist/inf-sys-secretary-methodist/internal/modules/extracurricular/domain/entities"
+)
+
+type deleteEventRepo interface {
+	GetByID(ctx context.Context, id int64) (*entities.ExtracurricularEvent, error)
+	Delete(ctx context.Context, id int64) error
+}
+
+// DeleteEventUseCase removes the event row (participants cascade via
+// FK ON DELETE CASCADE per migration 046) after authz + load.
+type DeleteEventUseCase struct {
+	repo  deleteEventRepo
+	audit AuditSink
+}
+
+// NewDeleteEventUseCase wires the use case.
+func NewDeleteEventUseCase(repo deleteEventRepo, audit AuditSink) *DeleteEventUseCase {
+	if repo == nil {
+		panic("extracurricular: NewDeleteEventUseCase requires non-nil repo")
+	}
+	return &DeleteEventUseCase{repo: repo, audit: audit}
+}
+
+// Execute deletes the event after loading it for authz check. Pair 5 RED stub.
+func (uc *DeleteEventUseCase) Execute(ctx context.Context, actorID int64, actorRole string, isAdmin bool, eventID int64) error {
+	_ = actorID
+	_ = actorRole
+	_ = isAdmin
+	_ = eventID
+	_ = ctx
+	return errors.New("not implemented (Pair 5 RED stub)")
+}

--- a/internal/modules/extracurricular/application/usecases/event_notifier.go
+++ b/internal/modules/extracurricular/application/usecases/event_notifier.go
@@ -1,0 +1,26 @@
+package usecases
+
+import "context"
+
+// EventNotifier is the narrow notification port. Concrete adapter
+// wired в main.go bridges to NotificationUseCase per plan ADR-7 —
+// backend slice (v0.162.0) defines the port; production wiring lands
+// в v0.163.0 alongside frontend.
+//
+// Methods correspond to the lifecycle events that surface к target
+// audience: published / canceled / completed / updated. Implementations
+// resolve the audience cohort и filter per user prefs.
+type EventNotifier interface {
+	NotifyEventPublished(ctx context.Context, eventID int64, title, audience string)
+	NotifyEventCancelled(ctx context.Context, eventID int64, title, audience string)
+	NotifyEventUpdated(ctx context.Context, eventID int64, title, audience string)
+}
+
+// noopNotifier is the zero-value fallback when DI does not wire a
+// concrete notifier (e.g. в unit tests). Methods are no-op so use
+// cases never crash on nil dispatch.
+type noopNotifier struct{}
+
+func (noopNotifier) NotifyEventPublished(_ context.Context, _ int64, _, _ string) {}
+func (noopNotifier) NotifyEventCancelled(_ context.Context, _ int64, _, _ string) {}
+func (noopNotifier) NotifyEventUpdated(_ context.Context, _ int64, _, _ string)   {}

--- a/internal/modules/extracurricular/application/usecases/get_event_usecase.go
+++ b/internal/modules/extracurricular/application/usecases/get_event_usecase.go
@@ -2,9 +2,9 @@ package usecases
 
 import (
 	"context"
-	"errors"
 
 	"github.com/inf-sys-secretary-methodologist/inf-sys-secretary-methodist/internal/modules/extracurricular/domain/entities"
+	"github.com/inf-sys-secretary-methodologist/inf-sys-secretary-methodist/internal/modules/extracurricular/domain/repositories"
 )
 
 type getEventRepo interface {
@@ -12,7 +12,8 @@ type getEventRepo interface {
 }
 
 // GetEventUseCase fetches one event by id и applies audience filter
-// для non-admin callers.
+// для non-admin callers. Audience mismatch returns ErrEventNotFound
+// to hide existence per security best practice.
 type GetEventUseCase struct {
 	repo getEventRepo
 }
@@ -25,13 +26,17 @@ func NewGetEventUseCase(repo getEventRepo) *GetEventUseCase {
 	return &GetEventUseCase{repo: repo}
 }
 
-// Execute fetches the event и filters via CanViewEvent + isAdmin
-// для non-admin callers. Returns ErrEventNotFound для audience
-// mismatch — hides existence per security best practice. Pair 5 RED stub.
+// Execute fetches the event и applies audience filter.
 func (uc *GetEventUseCase) Execute(ctx context.Context, actorRole string, isAdmin bool, eventID int64) (*entities.ExtracurricularEvent, error) {
-	_ = ctx
-	_ = actorRole
-	_ = isAdmin
-	_ = eventID
-	return nil, errors.New("not implemented (Pair 5 RED stub)")
+	e, err := uc.repo.GetByID(ctx, eventID)
+	if err != nil {
+		return nil, err
+	}
+	if isAdmin {
+		return e, nil
+	}
+	if !entities.CanViewEvent(actorRole, e.TargetAudience()) {
+		return nil, repositories.ErrEventNotFound
+	}
+	return e, nil
 }

--- a/internal/modules/extracurricular/application/usecases/get_event_usecase.go
+++ b/internal/modules/extracurricular/application/usecases/get_event_usecase.go
@@ -1,0 +1,37 @@
+package usecases
+
+import (
+	"context"
+	"errors"
+
+	"github.com/inf-sys-secretary-methodologist/inf-sys-secretary-methodist/internal/modules/extracurricular/domain/entities"
+)
+
+type getEventRepo interface {
+	GetByID(ctx context.Context, id int64) (*entities.ExtracurricularEvent, error)
+}
+
+// GetEventUseCase fetches one event by id и applies audience filter
+// для non-admin callers.
+type GetEventUseCase struct {
+	repo getEventRepo
+}
+
+// NewGetEventUseCase wires the read-side use case.
+func NewGetEventUseCase(repo getEventRepo) *GetEventUseCase {
+	if repo == nil {
+		panic("extracurricular: NewGetEventUseCase requires non-nil repo")
+	}
+	return &GetEventUseCase{repo: repo}
+}
+
+// Execute fetches the event и filters via CanViewEvent + isAdmin
+// для non-admin callers. Returns ErrEventNotFound для audience
+// mismatch — hides existence per security best practice. Pair 5 RED stub.
+func (uc *GetEventUseCase) Execute(ctx context.Context, actorRole string, isAdmin bool, eventID int64) (*entities.ExtracurricularEvent, error) {
+	_ = ctx
+	_ = actorRole
+	_ = isAdmin
+	_ = eventID
+	return nil, errors.New("not implemented (Pair 5 RED stub)")
+}

--- a/internal/modules/extracurricular/application/usecases/list_events_usecase.go
+++ b/internal/modules/extracurricular/application/usecases/list_events_usecase.go
@@ -1,0 +1,50 @@
+package usecases
+
+import (
+	"context"
+	"errors"
+
+	"github.com/inf-sys-secretary-methodologist/inf-sys-secretary-methodist/internal/modules/extracurricular/domain/repositories"
+)
+
+// ListEventsInput is the public DTO для ListEvents. Matches handler
+// query params — Status/Category/FromDate/ToDate strings, OrganizerID
+// optional, pagination Limit+Offset.
+type ListEventsInput struct {
+	Status      string
+	Category    string
+	OrganizerID int64
+	FromDate    string
+	ToDate      string
+	Limit       int
+	Offset      int
+}
+
+type listEventsRepo interface {
+	List(ctx context.Context, filter repositories.EventListFilter) (repositories.EventListResult, error)
+}
+
+// ListEventsUseCase returns a paginated, audience-filtered slice of
+// event summaries.
+type ListEventsUseCase struct {
+	repo listEventsRepo
+}
+
+// NewListEventsUseCase wires the read-side use case.
+func NewListEventsUseCase(repo listEventsRepo) *ListEventsUseCase {
+	if repo == nil {
+		panic("extracurricular: NewListEventsUseCase requires non-nil repo")
+	}
+	return &ListEventsUseCase{repo: repo}
+}
+
+// Execute applies the audience visibility filter за каллер's role
+// (admin = all audiences; per-role = restricted set) и delegates к
+// repo.List. Pair 5 RED stub.
+func (uc *ListEventsUseCase) Execute(ctx context.Context, actorRole string, isAdmin bool, in ListEventsInput) (repositories.EventListResult, error) {
+	_ = ctx
+	_ = actorRole
+	_ = isAdmin
+	_ = in
+	return repositories.EventListResult{}, errors.New("not implemented (Pair 5 RED stub)")
+}

--- a/internal/modules/extracurricular/application/usecases/list_events_usecase.go
+++ b/internal/modules/extracurricular/application/usecases/list_events_usecase.go
@@ -2,14 +2,14 @@ package usecases
 
 import (
 	"context"
-	"errors"
 
+	"github.com/inf-sys-secretary-methodologist/inf-sys-secretary-methodist/internal/modules/extracurricular/domain/entities"
 	"github.com/inf-sys-secretary-methodologist/inf-sys-secretary-methodist/internal/modules/extracurricular/domain/repositories"
 )
 
-// ListEventsInput is the public DTO для ListEvents. Matches handler
-// query params — Status/Category/FromDate/ToDate strings, OrganizerID
-// optional, pagination Limit+Offset.
+// ListEventsInput is the public DTO для ListEvents. Mirror к
+// handler query params: optional status / category / organizer
+// filter + date range + pagination.
 type ListEventsInput struct {
 	Status      string
 	Category    string
@@ -38,13 +38,39 @@ func NewListEventsUseCase(repo listEventsRepo) *ListEventsUseCase {
 	return &ListEventsUseCase{repo: repo}
 }
 
-// Execute applies the audience visibility filter за каллер's role
-// (admin = all audiences; per-role = restricted set) и delegates к
-// repo.List. Pair 5 RED stub.
+// Execute applies role-aware audience visibility filter then delegates
+// к repo.List. Admin sees all audiences (empty AudienceIn → no filter);
+// non-admin restricted к the set visible per ADR-6.
 func (uc *ListEventsUseCase) Execute(ctx context.Context, actorRole string, isAdmin bool, in ListEventsInput) (repositories.EventListResult, error) {
-	_ = ctx
-	_ = actorRole
-	_ = isAdmin
-	_ = in
-	return repositories.EventListResult{}, errors.New("not implemented (Pair 5 RED stub)")
+	filter := repositories.EventListFilter{
+		Status:      in.Status,
+		Category:    in.Category,
+		OrganizerID: in.OrganizerID,
+		FromDate:    in.FromDate,
+		ToDate:      in.ToDate,
+		Limit:       in.Limit,
+		Offset:      in.Offset,
+	}
+	if !isAdmin {
+		filter.AudienceIn = visibleAudiences(actorRole)
+	}
+	return uc.repo.List(ctx, filter)
+}
+
+// visibleAudiences returns the subset of TargetAudience values
+// visible к the given role per ADR-6. Mirror к CanViewEvent matrix.
+func visibleAudiences(role string) []string {
+	switch role {
+	case "student":
+		return []string{string(entities.TargetAudienceAll), string(entities.TargetAudienceStudents)}
+	case "teacher":
+		return []string{string(entities.TargetAudienceAll), string(entities.TargetAudienceTeachers)}
+	case "methodist", "academic_secretary", "system_admin":
+		return []string{
+			string(entities.TargetAudienceAll),
+			string(entities.TargetAudienceStaff),
+		}
+	}
+	// unknown role — only `all` visible (mirror CanViewEvent default-allow для all)
+	return []string{string(entities.TargetAudienceAll)}
 }

--- a/internal/modules/extracurricular/application/usecases/register_participant_usecase.go
+++ b/internal/modules/extracurricular/application/usecases/register_participant_usecase.go
@@ -2,7 +2,6 @@ package usecases
 
 import (
 	"context"
-	"errors"
 	"time"
 
 	"github.com/inf-sys-secretary-methodologist/inf-sys-secretary-methodist/internal/modules/extracurricular/domain/entities"
@@ -32,12 +31,22 @@ func NewRegisterParticipantUseCase(repo registerParticipantRepo, audit AuditSink
 	return &RegisterParticipantUseCase{repo: repo, audit: audit, clock: clock}
 }
 
-// Execute registers actorID as participant в the event. Self-register
-// only — teacher-on-behalf NOT в scope для backend slice (deferred).
-// Pair 5 RED stub.
+// Execute loads the event, runs the aggregate Register method к check
+// status + capacity + duplicate, then persists the participant row.
 func (uc *RegisterParticipantUseCase) Execute(ctx context.Context, actorID int64, eventID int64) error {
-	_ = ctx
-	_ = actorID
-	_ = eventID
-	return errors.New("not implemented (Pair 5 RED stub)")
+	e, err := uc.repo.GetByID(ctx, eventID)
+	if err != nil {
+		return err
+	}
+	now := uc.clock()
+	if err := e.Register(actorID, now); err != nil {
+		emitAudit(uc.audit, ctx, "extracurricular.register_denied",
+			denialFields(actorID, eventID, err.Error(), "register_blocked"))
+		return err
+	}
+	if err := uc.repo.AddParticipant(ctx, eventID, actorID, now); err != nil {
+		return err
+	}
+	emitAudit(uc.audit, ctx, "extracurricular.participant_registered", actionFields(actorID, eventID))
+	return nil
 }

--- a/internal/modules/extracurricular/application/usecases/register_participant_usecase.go
+++ b/internal/modules/extracurricular/application/usecases/register_participant_usecase.go
@@ -1,0 +1,43 @@
+package usecases
+
+import (
+	"context"
+	"errors"
+	"time"
+
+	"github.com/inf-sys-secretary-methodologist/inf-sys-secretary-methodist/internal/modules/extracurricular/domain/entities"
+)
+
+type registerParticipantRepo interface {
+	GetByID(ctx context.Context, id int64) (*entities.ExtracurricularEvent, error)
+	AddParticipant(ctx context.Context, eventID, userID int64, registeredAt time.Time) error
+}
+
+// RegisterParticipantUseCase adds caller as participant к the event
+// (self-register only; teacher-on-behalf out-of-scope для backend slice).
+type RegisterParticipantUseCase struct {
+	repo  registerParticipantRepo
+	audit AuditSink
+	clock func() time.Time
+}
+
+// NewRegisterParticipantUseCase wires the use case.
+func NewRegisterParticipantUseCase(repo registerParticipantRepo, audit AuditSink, clock func() time.Time) *RegisterParticipantUseCase {
+	if repo == nil {
+		panic("extracurricular: NewRegisterParticipantUseCase requires non-nil repo")
+	}
+	if clock == nil {
+		clock = time.Now
+	}
+	return &RegisterParticipantUseCase{repo: repo, audit: audit, clock: clock}
+}
+
+// Execute registers actorID as participant в the event. Self-register
+// only — teacher-on-behalf NOT в scope для backend slice (deferred).
+// Pair 5 RED stub.
+func (uc *RegisterParticipantUseCase) Execute(ctx context.Context, actorID int64, eventID int64) error {
+	_ = ctx
+	_ = actorID
+	_ = eventID
+	return errors.New("not implemented (Pair 5 RED stub)")
+}

--- a/internal/modules/extracurricular/application/usecases/unregister_participant_usecase.go
+++ b/internal/modules/extracurricular/application/usecases/unregister_participant_usecase.go
@@ -1,0 +1,37 @@
+package usecases
+
+import (
+	"context"
+	"errors"
+
+	"github.com/inf-sys-secretary-methodologist/inf-sys-secretary-methodist/internal/modules/extracurricular/domain/entities"
+)
+
+type unregisterParticipantRepo interface {
+	GetByID(ctx context.Context, id int64) (*entities.ExtracurricularEvent, error)
+	RemoveParticipant(ctx context.Context, eventID, userID int64) error
+}
+
+// UnregisterParticipantUseCase removes caller's participant entry от
+// the event.
+type UnregisterParticipantUseCase struct {
+	repo  unregisterParticipantRepo
+	audit AuditSink
+}
+
+// NewUnregisterParticipantUseCase wires the use case.
+func NewUnregisterParticipantUseCase(repo unregisterParticipantRepo, audit AuditSink) *UnregisterParticipantUseCase {
+	if repo == nil {
+		panic("extracurricular: NewUnregisterParticipantUseCase requires non-nil repo")
+	}
+	return &UnregisterParticipantUseCase{repo: repo, audit: audit}
+}
+
+// Execute removes actorID's participant entry от the event.
+// Pair 5 RED stub.
+func (uc *UnregisterParticipantUseCase) Execute(ctx context.Context, actorID int64, eventID int64) error {
+	_ = ctx
+	_ = actorID
+	_ = eventID
+	return errors.New("not implemented (Pair 5 RED stub)")
+}

--- a/internal/modules/extracurricular/application/usecases/unregister_participant_usecase.go
+++ b/internal/modules/extracurricular/application/usecases/unregister_participant_usecase.go
@@ -2,7 +2,6 @@ package usecases
 
 import (
 	"context"
-	"errors"
 
 	"github.com/inf-sys-secretary-methodologist/inf-sys-secretary-methodist/internal/modules/extracurricular/domain/entities"
 )
@@ -27,11 +26,15 @@ func NewUnregisterParticipantUseCase(repo unregisterParticipantRepo, audit Audit
 	return &UnregisterParticipantUseCase{repo: repo, audit: audit}
 }
 
-// Execute removes actorID's participant entry от the event.
-// Pair 5 RED stub.
+// Execute loads the event (ErrEventNotFound surfaces для 404 mapping),
+// then deletes the participant row.
 func (uc *UnregisterParticipantUseCase) Execute(ctx context.Context, actorID int64, eventID int64) error {
-	_ = ctx
-	_ = actorID
-	_ = eventID
-	return errors.New("not implemented (Pair 5 RED stub)")
+	if _, err := uc.repo.GetByID(ctx, eventID); err != nil {
+		return err
+	}
+	if err := uc.repo.RemoveParticipant(ctx, eventID, actorID); err != nil {
+		return err
+	}
+	emitAudit(uc.audit, ctx, "extracurricular.participant_unregistered", actionFields(actorID, eventID))
+	return nil
 }

--- a/internal/modules/extracurricular/application/usecases/update_event_usecase.go
+++ b/internal/modules/extracurricular/application/usecases/update_event_usecase.go
@@ -8,9 +8,8 @@ import (
 	"github.com/inf-sys-secretary-methodologist/inf-sys-secretary-methodist/internal/modules/extracurricular/domain/entities"
 )
 
-// UpdateEventInput bundles update fields. Pointer-less; full replace
-// semantics (UI sends full state) — simpler than tri-state pointers
-// для greenfield. MaxCapacity nil = explicit "unlimited".
+// UpdateEventInput bundles update fields. Full-replace semantics
+// (no pointer tri-state) — UI sends complete state.
 type UpdateEventInput struct {
 	ID             int64
 	Title          string
@@ -53,13 +52,38 @@ func NewUpdateEventUseCase(repo updateEventRepo, audit AuditSink, notifier Event
 	return &UpdateEventUseCase{repo: repo, audit: audit, notifier: notifier, clock: clock}
 }
 
-// Execute runs UpdateBasics on the loaded aggregate с authz + optimistic
-// lock conflict translation. Pair 5 RED stub.
+// Execute loads + authz + UpdateBasics + persists.
 func (uc *UpdateEventUseCase) Execute(ctx context.Context, actorID int64, actorRole string, isAdmin bool, in UpdateEventInput) (*entities.ExtracurricularEvent, error) {
-	_ = actorID
-	_ = actorRole
-	_ = isAdmin
-	_ = in
-	_ = ctx
-	return nil, errors.New("not implemented (Pair 5 RED stub)")
+	e, err := uc.repo.GetByID(ctx, in.ID)
+	if err != nil {
+		return nil, err
+	}
+	if err := entities.AuthorizeEventEdit(actorID, e.OrganizerID(), actorRole, isAdmin); err != nil {
+		emitAudit(uc.audit, ctx, "extracurricular.event_update_denied",
+			denialFields(actorID, in.ID, "not organizer / not admin", "forbidden"))
+		return nil, err
+	}
+	if err := e.UpdateBasics(entities.UpdateEventBasicsParams{
+		Title:          in.Title,
+		Description:    in.Description,
+		Category:       in.Category,
+		TargetAudience: in.TargetAudience,
+		Location:       in.Location,
+		StartAt:        in.StartAt,
+		EndAt:          in.EndAt,
+		MaxCapacity:    in.MaxCapacity,
+		Now:            uc.clock(),
+	}); err != nil {
+		if errors.Is(err, entities.ErrInvalidEvent) {
+			emitAudit(uc.audit, ctx, "extracurricular.event_update_denied",
+				denialFields(actorID, in.ID, err.Error(), "invalid"))
+		}
+		return nil, err
+	}
+	if err := uc.repo.Update(ctx, e); err != nil {
+		return nil, err
+	}
+	emitAudit(uc.audit, ctx, "extracurricular.event_updated", actionFields(actorID, e.ID))
+	uc.notifier.NotifyEventUpdated(ctx, e.ID, e.Title(), string(e.TargetAudience()))
+	return e, nil
 }

--- a/internal/modules/extracurricular/application/usecases/update_event_usecase.go
+++ b/internal/modules/extracurricular/application/usecases/update_event_usecase.go
@@ -1,0 +1,65 @@
+package usecases
+
+import (
+	"context"
+	"errors"
+	"time"
+
+	"github.com/inf-sys-secretary-methodologist/inf-sys-secretary-methodist/internal/modules/extracurricular/domain/entities"
+)
+
+// UpdateEventInput bundles update fields. Pointer-less; full replace
+// semantics (UI sends full state) — simpler than tri-state pointers
+// для greenfield. MaxCapacity nil = explicit "unlimited".
+type UpdateEventInput struct {
+	ID             int64
+	Title          string
+	Description    string
+	Category       entities.Category
+	TargetAudience entities.TargetAudience
+	Location       string
+	StartAt        time.Time
+	EndAt          time.Time
+	MaxCapacity    *int
+}
+
+type updateEventRepo interface {
+	GetByID(ctx context.Context, id int64) (*entities.ExtracurricularEvent, error)
+	Update(ctx context.Context, e *entities.ExtracurricularEvent) error
+}
+
+// UpdateEventUseCase applies a content edit к an existing event after
+// loading + authz + invariant gates. Optimistic lock conflicts
+// surface as repositories.ErrEventVersionConflict для handler 409.
+type UpdateEventUseCase struct {
+	repo     updateEventRepo
+	audit    AuditSink
+	notifier EventNotifier
+	clock    func() time.Time
+}
+
+// NewUpdateEventUseCase wires the use case. Nil notifier defaults
+// к noopNotifier (production wiring lands в v0.163.0 frontend slice).
+func NewUpdateEventUseCase(repo updateEventRepo, audit AuditSink, notifier EventNotifier, clock func() time.Time) *UpdateEventUseCase {
+	if repo == nil {
+		panic("extracurricular: NewUpdateEventUseCase requires non-nil repo")
+	}
+	if notifier == nil {
+		notifier = noopNotifier{}
+	}
+	if clock == nil {
+		clock = time.Now
+	}
+	return &UpdateEventUseCase{repo: repo, audit: audit, notifier: notifier, clock: clock}
+}
+
+// Execute runs UpdateBasics on the loaded aggregate с authz + optimistic
+// lock conflict translation. Pair 5 RED stub.
+func (uc *UpdateEventUseCase) Execute(ctx context.Context, actorID int64, actorRole string, isAdmin bool, in UpdateEventInput) (*entities.ExtracurricularEvent, error) {
+	_ = actorID
+	_ = actorRole
+	_ = isAdmin
+	_ = in
+	_ = ctx
+	return nil, errors.New("not implemented (Pair 5 RED stub)")
+}

--- a/internal/modules/extracurricular/application/usecases/usecases_test.go
+++ b/internal/modules/extracurricular/application/usecases/usecases_test.go
@@ -1,0 +1,431 @@
+package usecases
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/inf-sys-secretary-methodologist/inf-sys-secretary-methodist/internal/modules/extracurricular/domain/entities"
+	"github.com/inf-sys-secretary-methodologist/inf-sys-secretary-methodist/internal/modules/extracurricular/domain/repositories"
+)
+
+// ===== Fake repository — implements the full EventRepository surface =====
+
+type fakeRepo struct {
+	saveCalls         int
+	saveErr           error
+	saveAssignID      int64
+	updateCalls       int
+	updateErr         error
+	deleteCalls       int
+	deleteErr         error
+	getByIDErr        error
+	getByIDResult     *entities.ExtracurricularEvent
+	listErr           error
+	listResult        repositories.EventListResult
+	listFilterCapture repositories.EventListFilter
+	addPartErr        error
+	addPartCalls      int
+	addPartCapture    struct {
+		eventID, userID int64
+		at              time.Time
+	}
+	removePartErr     error
+	removePartCalls   int
+	removePartCapture struct{ eventID, userID int64 }
+}
+
+func (r *fakeRepo) Save(ctx context.Context, e *entities.ExtracurricularEvent) error {
+	r.saveCalls++
+	if r.saveErr != nil {
+		return r.saveErr
+	}
+	if r.saveAssignID != 0 {
+		e.ID = r.saveAssignID
+	}
+	return nil
+}
+func (r *fakeRepo) GetByID(_ context.Context, _ int64) (*entities.ExtracurricularEvent, error) {
+	if r.getByIDErr != nil {
+		return nil, r.getByIDErr
+	}
+	return r.getByIDResult, nil
+}
+func (r *fakeRepo) Update(_ context.Context, _ *entities.ExtracurricularEvent) error {
+	r.updateCalls++
+	return r.updateErr
+}
+func (r *fakeRepo) Delete(_ context.Context, _ int64) error {
+	r.deleteCalls++
+	return r.deleteErr
+}
+func (r *fakeRepo) List(_ context.Context, f repositories.EventListFilter) (repositories.EventListResult, error) {
+	r.listFilterCapture = f
+	if r.listErr != nil {
+		return repositories.EventListResult{}, r.listErr
+	}
+	return r.listResult, nil
+}
+func (r *fakeRepo) AddParticipant(_ context.Context, eventID, userID int64, at time.Time) error {
+	r.addPartCalls++
+	r.addPartCapture.eventID = eventID
+	r.addPartCapture.userID = userID
+	r.addPartCapture.at = at
+	return r.addPartErr
+}
+func (r *fakeRepo) RemoveParticipant(_ context.Context, eventID, userID int64) error {
+	r.removePartCalls++
+	r.removePartCapture.eventID = eventID
+	r.removePartCapture.userID = userID
+	return r.removePartErr
+}
+
+// recordingAudit captures every emitted event for assertion.
+type recordingAudit struct {
+	events []auditCapture
+}
+type auditCapture struct {
+	action   string
+	resource string
+	fields   map[string]any
+}
+
+func (r *recordingAudit) LogAuditEvent(_ context.Context, action, resource string, fields map[string]any) {
+	r.events = append(r.events, auditCapture{action: action, resource: resource, fields: fields})
+}
+
+func fixedClock(t time.Time) func() time.Time { return func() time.Time { return t } }
+
+func validCreateInput() CreateEventInput {
+	now := time.Date(2026, 5, 24, 12, 0, 0, 0, time.UTC)
+	return CreateEventInput{
+		Title:          "Концерт",
+		Description:    "desc",
+		Category:       entities.CategoryCultural,
+		TargetAudience: entities.TargetAudienceAll,
+		Location:       "loc",
+		StartAt:        now.Add(48 * time.Hour),
+		EndAt:          now.Add(50 * time.Hour),
+	}
+}
+
+func newSampleEvent(t *testing.T, organizerID int64, status entities.Status) *entities.ExtracurricularEvent {
+	t.Helper()
+	now := time.Date(2026, 5, 24, 12, 0, 0, 0, time.UTC)
+	e, err := entities.NewExtracurricularEvent(entities.NewExtracurricularEventParams{
+		Title:          "Концерт",
+		Description:    "desc",
+		Category:       entities.CategoryCultural,
+		TargetAudience: entities.TargetAudienceAll,
+		Location:       "loc",
+		StartAt:        now.Add(48 * time.Hour),
+		EndAt:          now.Add(50 * time.Hour),
+		OrganizerID:    organizerID,
+		Now:            now,
+	})
+	if err != nil {
+		t.Fatalf("setup NewExtracurricularEvent: %v", err)
+	}
+	if status == entities.StatusPublished {
+		if err := e.Publish(now); err != nil {
+			t.Fatalf("setup Publish: %v", err)
+		}
+	}
+	e.ID = 99
+	return e
+}
+
+// ===== CreateEvent =====
+
+func TestCreateEventUseCase_HappyPath(t *testing.T) {
+	repo := &fakeRepo{saveAssignID: 99}
+	audit := &recordingAudit{}
+	now := time.Date(2026, 5, 24, 12, 0, 0, 0, time.UTC)
+	uc := NewCreateEventUseCase(repo, audit, fixedClock(now))
+	e, err := uc.Execute(context.Background(), 42, "methodist", false, validCreateInput())
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	if e == nil || e.ID != 99 {
+		t.Fatalf("event.ID = %v, want 99", e)
+	}
+	if e.OrganizerID() != 42 {
+		t.Errorf("OrganizerID = %d, want 42 (actor)", e.OrganizerID())
+	}
+	if repo.saveCalls != 1 {
+		t.Errorf("saveCalls = %d, want 1", repo.saveCalls)
+	}
+	if len(audit.events) == 0 || audit.events[0].action != "extracurricular.event_created" {
+		t.Errorf("audit events = %+v, want extracurricular.event_created", audit.events)
+	}
+}
+
+func TestCreateEventUseCase_DeniedForTeacher(t *testing.T) {
+	repo := &fakeRepo{saveAssignID: 99}
+	audit := &recordingAudit{}
+	uc := NewCreateEventUseCase(repo, audit, fixedClock(time.Now()))
+	_, err := uc.Execute(context.Background(), 42, "teacher", false, validCreateInput())
+	if err == nil {
+		t.Fatal("expected denial, got nil")
+	}
+	if !errors.Is(err, entities.ErrEventScopeForbidden) {
+		t.Errorf("err = %v, want ErrEventScopeForbidden", err)
+	}
+	if repo.saveCalls != 0 {
+		t.Errorf("saveCalls = %d, want 0 (denied before persistence)", repo.saveCalls)
+	}
+	hasDenial := false
+	for _, ev := range audit.events {
+		if ev.action == "extracurricular.event_create_denied" {
+			hasDenial = true
+			if ev.fields["code"] != "forbidden" {
+				t.Errorf("denial code = %v, want forbidden", ev.fields["code"])
+			}
+		}
+	}
+	if !hasDenial {
+		t.Errorf("missing denial audit event, got: %+v", audit.events)
+	}
+}
+
+func TestCreateEventUseCase_InvalidInput(t *testing.T) {
+	repo := &fakeRepo{}
+	audit := &recordingAudit{}
+	uc := NewCreateEventUseCase(repo, audit, fixedClock(time.Now()))
+	in := validCreateInput()
+	in.Title = ""
+	_, err := uc.Execute(context.Background(), 42, "methodist", false, in)
+	if !errors.Is(err, entities.ErrInvalidEvent) {
+		t.Errorf("err = %v, want ErrInvalidEvent", err)
+	}
+	if repo.saveCalls != 0 {
+		t.Errorf("saveCalls = %d, want 0", repo.saveCalls)
+	}
+}
+
+// ===== UpdateEvent =====
+
+func TestUpdateEventUseCase_HappyPath(t *testing.T) {
+	existing := newSampleEvent(t, 42, entities.StatusDraft)
+	repo := &fakeRepo{getByIDResult: existing}
+	audit := &recordingAudit{}
+	now := time.Date(2026, 5, 24, 14, 0, 0, 0, time.UTC)
+	uc := NewUpdateEventUseCase(repo, audit, nil, fixedClock(now))
+	in := UpdateEventInput{
+		ID:             99,
+		Title:          "Обновлённый",
+		Description:    "new desc",
+		Category:       entities.CategoryCultural,
+		TargetAudience: entities.TargetAudienceAll,
+		Location:       "new loc",
+		StartAt:        now.Add(48 * time.Hour),
+		EndAt:          now.Add(50 * time.Hour),
+	}
+	_, err := uc.Execute(context.Background(), 42, "methodist", false, in)
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	if repo.updateCalls != 1 {
+		t.Errorf("updateCalls = %d, want 1", repo.updateCalls)
+	}
+	if existing.Title() != "Обновлённый" {
+		t.Errorf("entity not mutated; Title = %q", existing.Title())
+	}
+}
+
+func TestUpdateEventUseCase_DeniedForOtherMethodist(t *testing.T) {
+	existing := newSampleEvent(t, 42, entities.StatusDraft)
+	repo := &fakeRepo{getByIDResult: existing}
+	audit := &recordingAudit{}
+	uc := NewUpdateEventUseCase(repo, audit, nil, fixedClock(time.Now()))
+	in := UpdateEventInput{
+		ID:             99,
+		Title:          "x",
+		Category:       entities.CategoryCultural,
+		TargetAudience: entities.TargetAudienceAll,
+		StartAt:        time.Now().Add(48 * time.Hour),
+		EndAt:          time.Now().Add(50 * time.Hour),
+	}
+	_, err := uc.Execute(context.Background(), 100, "methodist", false, in)
+	if !errors.Is(err, entities.ErrEventScopeForbidden) {
+		t.Errorf("err = %v, want ErrEventScopeForbidden", err)
+	}
+}
+
+func TestUpdateEventUseCase_VersionConflictPropagates(t *testing.T) {
+	existing := newSampleEvent(t, 42, entities.StatusDraft)
+	repo := &fakeRepo{getByIDResult: existing, updateErr: repositories.ErrEventVersionConflict}
+	uc := NewUpdateEventUseCase(repo, nil, nil, fixedClock(time.Now()))
+	in := UpdateEventInput{
+		ID:             99,
+		Title:          "x",
+		Category:       entities.CategoryCultural,
+		TargetAudience: entities.TargetAudienceAll,
+		StartAt:        time.Now().Add(48 * time.Hour),
+		EndAt:          time.Now().Add(50 * time.Hour),
+	}
+	_, err := uc.Execute(context.Background(), 42, "methodist", false, in)
+	if !errors.Is(err, repositories.ErrEventVersionConflict) {
+		t.Errorf("err = %v, want ErrEventVersionConflict", err)
+	}
+}
+
+// ===== DeleteEvent =====
+
+func TestDeleteEventUseCase_HappyPath(t *testing.T) {
+	existing := newSampleEvent(t, 42, entities.StatusDraft)
+	repo := &fakeRepo{getByIDResult: existing}
+	audit := &recordingAudit{}
+	uc := NewDeleteEventUseCase(repo, audit)
+	if err := uc.Execute(context.Background(), 42, "methodist", false, 99); err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	if repo.deleteCalls != 1 {
+		t.Errorf("deleteCalls = %d, want 1", repo.deleteCalls)
+	}
+}
+
+func TestDeleteEventUseCase_NotFound(t *testing.T) {
+	repo := &fakeRepo{getByIDErr: repositories.ErrEventNotFound}
+	uc := NewDeleteEventUseCase(repo, nil)
+	err := uc.Execute(context.Background(), 42, "methodist", false, 404)
+	if !errors.Is(err, repositories.ErrEventNotFound) {
+		t.Errorf("err = %v, want ErrEventNotFound", err)
+	}
+}
+
+// ===== GetEvent =====
+
+func TestGetEventUseCase_AdminViewsAnyAudience(t *testing.T) {
+	existing := newSampleEvent(t, 42, entities.StatusPublished)
+	// even staff-only event visible к admin via isAdmin flag
+	repo := &fakeRepo{getByIDResult: existing}
+	uc := NewGetEventUseCase(repo)
+	e, err := uc.Execute(context.Background(), "system_admin", true, 99)
+	if err != nil || e == nil {
+		t.Fatalf("admin Execute: err=%v e=%v", err, e)
+	}
+}
+
+func TestGetEventUseCase_StudentCannotViewTeachersAudience(t *testing.T) {
+	now := time.Date(2026, 5, 24, 12, 0, 0, 0, time.UTC)
+	e, _ := entities.NewExtracurricularEvent(entities.NewExtracurricularEventParams{
+		Title: "x", Category: entities.CategoryCultural,
+		TargetAudience: entities.TargetAudienceTeachers,
+		StartAt:        now.Add(48 * time.Hour), EndAt: now.Add(50 * time.Hour),
+		OrganizerID: 42, Now: now,
+	})
+	e.ID = 99
+	repo := &fakeRepo{getByIDResult: e}
+	uc := NewGetEventUseCase(repo)
+	_, err := uc.Execute(context.Background(), "student", false, 99)
+	if !errors.Is(err, repositories.ErrEventNotFound) {
+		t.Errorf("err = %v, want ErrEventNotFound (hide existence)", err)
+	}
+}
+
+// ===== ListEvents =====
+
+func TestListEventsUseCase_StudentSeesAllAndStudentsAudiences(t *testing.T) {
+	repo := &fakeRepo{listResult: repositories.EventListResult{Total: 3}}
+	uc := NewListEventsUseCase(repo)
+	_, err := uc.Execute(context.Background(), "student", false, ListEventsInput{})
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	got := repo.listFilterCapture.AudienceIn
+	if !containsAll(got, []string{"all", "students"}) {
+		t.Errorf("AudienceIn = %v, want subset {all, students}", got)
+	}
+}
+
+func TestListEventsUseCase_AdminSeesAllAudiences(t *testing.T) {
+	repo := &fakeRepo{listResult: repositories.EventListResult{Total: 7}}
+	uc := NewListEventsUseCase(repo)
+	_, err := uc.Execute(context.Background(), "system_admin", true, ListEventsInput{})
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	if len(repo.listFilterCapture.AudienceIn) != 0 {
+		t.Errorf("admin AudienceIn = %v, want empty (no audience filter)", repo.listFilterCapture.AudienceIn)
+	}
+}
+
+func containsAll(s []string, want []string) bool {
+	m := map[string]bool{}
+	for _, v := range s {
+		m[v] = true
+	}
+	for _, w := range want {
+		if !m[w] {
+			return false
+		}
+	}
+	return true
+}
+
+// ===== RegisterParticipant =====
+
+func TestRegisterParticipantUseCase_HappyPath(t *testing.T) {
+	existing := newSampleEvent(t, 42, entities.StatusPublished)
+	repo := &fakeRepo{getByIDResult: existing}
+	audit := &recordingAudit{}
+	now := time.Date(2026, 5, 24, 14, 0, 0, 0, time.UTC)
+	uc := NewRegisterParticipantUseCase(repo, audit, fixedClock(now))
+	if err := uc.Execute(context.Background(), 101, 99); err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	if repo.addPartCalls != 1 {
+		t.Fatalf("addPartCalls = %d, want 1", repo.addPartCalls)
+	}
+	if repo.addPartCapture.eventID != 99 || repo.addPartCapture.userID != 101 {
+		t.Errorf("addPart capture wrong: %+v", repo.addPartCapture)
+	}
+	if !repo.addPartCapture.at.Equal(now) {
+		t.Errorf("registeredAt = %v, want clock %v", repo.addPartCapture.at, now)
+	}
+}
+
+func TestRegisterParticipantUseCase_EventNotFound(t *testing.T) {
+	repo := &fakeRepo{getByIDErr: repositories.ErrEventNotFound}
+	uc := NewRegisterParticipantUseCase(repo, nil, fixedClock(time.Now()))
+	err := uc.Execute(context.Background(), 101, 404)
+	if !errors.Is(err, repositories.ErrEventNotFound) {
+		t.Errorf("err = %v, want ErrEventNotFound", err)
+	}
+}
+
+func TestRegisterParticipantUseCase_RejectsDraftStatus(t *testing.T) {
+	existing := newSampleEvent(t, 42, entities.StatusDraft)
+	repo := &fakeRepo{getByIDResult: existing}
+	uc := NewRegisterParticipantUseCase(repo, nil, fixedClock(time.Now()))
+	err := uc.Execute(context.Background(), 101, 99)
+	if !errors.Is(err, entities.ErrEventNotOpenForRegistration) {
+		t.Errorf("err = %v, want ErrEventNotOpenForRegistration", err)
+	}
+}
+
+// ===== UnregisterParticipant =====
+
+func TestUnregisterParticipantUseCase_HappyPath(t *testing.T) {
+	existing := newSampleEvent(t, 42, entities.StatusPublished)
+	repo := &fakeRepo{getByIDResult: existing}
+	audit := &recordingAudit{}
+	uc := NewUnregisterParticipantUseCase(repo, audit)
+	if err := uc.Execute(context.Background(), 101, 99); err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	if repo.removePartCalls != 1 {
+		t.Errorf("removePartCalls = %d, want 1", repo.removePartCalls)
+	}
+}
+
+func TestUnregisterParticipantUseCase_NotFound(t *testing.T) {
+	repo := &fakeRepo{getByIDErr: repositories.ErrEventNotFound}
+	uc := NewUnregisterParticipantUseCase(repo, nil)
+	err := uc.Execute(context.Background(), 101, 404)
+	if !errors.Is(err, repositories.ErrEventNotFound) {
+		t.Errorf("err = %v, want ErrEventNotFound", err)
+	}
+}


### PR DESCRIPTION
## Summary

**Phase 4 of 5-PR split** для B3 Extracurricular events module (Refs #319, follows #323). PR-D: application layer — 7 use cases composing domain + repo. **930 LOC** under PR Size 1000 gate.

## Commits (TDD Pair 5 bundled)

- `a1685d0a` (RED) — 7 usecase stubs returning "not implemented" + bundled `usecases_test.go` (17 cases с fakeRepo + recordingAudit).
- `c320ff36` (GREEN) — 7 usecase implementations satisfying all RED tests.

## Use cases shipped

| UseCase | Behavior |
|---|---|
| CreateEventUseCase | AuthorizeEventCreate + NewExtracurricularEvent + repo.Save + audit |
| UpdateEventUseCase | load + AuthorizeEventEdit (self-edit для non-admin) + UpdateBasics + repo.Update + notifier |
| DeleteEventUseCase | load + AuthorizeEventEdit + repo.Delete (cascade via FK) |
| GetEventUseCase | repo.GetByID + CanViewEvent audience filter (admin override; mismatch → 404 hide existence) |
| ListEventsUseCase | visibleAudiences(role) → AudienceIn filter (admin sees all) |
| RegisterParticipantUseCase | load + aggregate.Register (status + capacity + duplicate) + repo.AddParticipant |
| UnregisterParticipantUseCase | load + repo.RemoveParticipant |

## Scaffolding

- `AuditSink` narrow port + `emitAudit` nil-safe + `actionFields` / `denialFields` canonical shapes
- `EventNotifier` narrow port + `noopNotifier` fallback (production wiring deferred к v0.163.0 frontend slice per plan ADR-7)
- 9 canonical audit events: event_created / event_updated / event_deleted / event_create_denied / event_update_denied / event_delete_denied / register_denied / participant_registered / participant_unregistered

## Out-of-scope (deferred к PR-E)

- HTTP handlers + integration tests
- main.go wiring (DI of 7 usecases + handler)
- Version bump 0.162.0 + release commit

## Test plan

- [x] `go test ./internal/modules/extracurricular/...` — green (17 usecase cases + all upstream)
- [x] `go build ./...` — clean
- [x] `golangci-lint` — 0 issues
- [x] Pre-commit hook clean
- [ ] CI passes (PR Size 930 < 1000)

🤖 Generated with [Claude Code](https://claude.com/claude-code)