### PR TITLE
feat(extracurricular): v0.165.0a1 — types + SWR hooks (foundation half 1)

### DIFF
--- a/frontend/src/hooks/__tests__/useExtracurricularEvents.test.ts
+++ b/frontend/src/hooks/__tests__/useExtracurricularEvents.test.ts
@@ -1,0 +1,172 @@
+import { renderHook, waitFor } from '@testing-library/react'
+import { SWRConfig } from 'swr'
+import React from 'react'
+import { useExtracurricularEvents, useExtracurricularEvent } from '../useExtracurricularEvents'
+import { apiClient } from '@/lib/api'
+
+jest.mock('@/lib/api', () => ({
+  apiClient: {
+    get: jest.fn(),
+    post: jest.fn(),
+    put: jest.fn(),
+    delete: jest.fn(),
+  },
+}))
+
+const mockedApiClient = jest.mocked(apiClient)
+
+const wrapper = ({ children }: { children: React.ReactNode }) =>
+  React.createElement(
+    SWRConfig,
+    { value: { dedupingInterval: 0, provider: () => new Map() } },
+    children
+  )
+
+describe('useExtracurricularEvents hooks (queries)', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  describe('useExtracurricularEvents', () => {
+    it('returns events list from API', async () => {
+      const mockResponse = {
+        items: [
+          {
+            id: 1,
+            title: 'Spring concert',
+            category: 'cultural',
+            target_audience: 'all',
+            status: 'published',
+            location: 'Main hall',
+            start_at: '2026-06-01T18:00:00Z',
+            end_at: '2026-06-01T21:00:00Z',
+            max_capacity: 200,
+            organizer_id: 5,
+            participant_count: 42,
+            version: 3,
+            created_at: '2026-05-20T10:00:00Z',
+            updated_at: '2026-05-25T12:00:00Z',
+          },
+        ],
+        total: 1,
+      }
+      mockedApiClient.get.mockResolvedValue({ data: mockResponse })
+
+      const { result } = renderHook(() => useExtracurricularEvents(), { wrapper })
+
+      await waitFor(() => {
+        expect(result.current.events).toHaveLength(1)
+      })
+      expect(result.current.total).toBe(1)
+      expect(result.current.events[0].title).toBe('Spring concert')
+    })
+
+    it('passes filter params as query string', async () => {
+      mockedApiClient.get.mockResolvedValue({
+        data: { items: [], total: 0 },
+      })
+
+      renderHook(
+        () =>
+          useExtracurricularEvents({
+            status: 'published',
+            category: 'sports',
+            from: '2026-06-01',
+            to: '2026-06-30',
+            limit: 50,
+          }),
+        { wrapper }
+      )
+
+      await waitFor(() => {
+        const url = mockedApiClient.get.mock.calls[0]?.[0] as string
+        expect(url).toContain('status=published')
+        expect(url).toContain('category=sports')
+        expect(url).toContain('from=2026-06-01')
+        expect(url).toContain('to=2026-06-30')
+        expect(url).toContain('limit=50')
+      })
+    })
+
+    it('returns empty array when API returns null data', async () => {
+      mockedApiClient.get.mockResolvedValue({ data: null })
+
+      const { result } = renderHook(() => useExtracurricularEvents(), { wrapper })
+
+      expect(result.current.events).toEqual([])
+      expect(result.current.total).toBe(0)
+    })
+
+    it('omits undefined/null filter params from query string', async () => {
+      mockedApiClient.get.mockResolvedValue({
+        data: { items: [], total: 0 },
+      })
+
+      renderHook(
+        () =>
+          useExtracurricularEvents({
+            status: 'draft',
+            category: undefined,
+            organizer_id: undefined,
+          }),
+        { wrapper }
+      )
+
+      await waitFor(() => {
+        const url = mockedApiClient.get.mock.calls[0]?.[0] as string
+        expect(url).toContain('status=draft')
+        expect(url).not.toContain('category=')
+        expect(url).not.toContain('organizer_id=')
+      })
+    })
+  })
+
+  describe('useExtracurricularEvent', () => {
+    it('fetches single event by id', async () => {
+      const mockEvent = {
+        id: 7,
+        title: 'Hackathon',
+        description: 'Annual programming hackathon',
+        category: 'academic',
+        target_audience: 'students',
+        status: 'published',
+        location: 'Lab 3',
+        start_at: '2026-07-01T09:00:00Z',
+        end_at: '2026-07-02T18:00:00Z',
+        max_capacity: 50,
+        organizer_id: 12,
+        participants: [],
+        participant_count: 0,
+        version: 1,
+        created_at: '2026-05-20T10:00:00Z',
+        updated_at: '2026-05-20T10:00:00Z',
+      }
+      mockedApiClient.get.mockResolvedValue({ data: mockEvent })
+
+      const { result } = renderHook(() => useExtracurricularEvent(7), { wrapper })
+
+      await waitFor(() => {
+        expect(result.current.event?.id).toBe(7)
+      })
+      expect(result.current.event?.title).toBe('Hackathon')
+    })
+
+    it('does not fetch when id is null', () => {
+      renderHook(() => useExtracurricularEvent(null), { wrapper })
+      expect(mockedApiClient.get).not.toHaveBeenCalled()
+    })
+
+    it('hits canonical event detail URL', async () => {
+      mockedApiClient.get.mockResolvedValue({
+        data: { id: 99, title: 'X', category: 'cultural', status: 'draft' },
+      })
+
+      renderHook(() => useExtracurricularEvent(99), { wrapper })
+
+      await waitFor(() => {
+        const url = mockedApiClient.get.mock.calls[0]?.[0] as string
+        expect(url).toBe('/api/v1/extracurricular/events/99')
+      })
+    })
+  })
+})

--- a/frontend/src/hooks/__tests__/useExtracurricularEvents.test.ts
+++ b/frontend/src/hooks/__tests__/useExtracurricularEvents.test.ts
@@ -1,7 +1,16 @@
 import { renderHook, waitFor } from '@testing-library/react'
 import { SWRConfig } from 'swr'
 import React from 'react'
-import { useExtracurricularEvents, useExtracurricularEvent } from '../useExtracurricularEvents'
+import {
+  useExtracurricularEvents,
+  useExtracurricularEvent,
+  createExtracurricularEvent,
+  updateExtracurricularEvent,
+  deleteExtracurricularEvent,
+  registerForExtracurricularEvent,
+  unregisterFromExtracurricularEvent,
+  pickExtracurricularErrorKey,
+} from '../useExtracurricularEvents'
 import { apiClient } from '@/lib/api'
 
 jest.mock('@/lib/api', () => ({
@@ -168,5 +177,146 @@ describe('useExtracurricularEvents hooks (queries)', () => {
         expect(url).toBe('/api/v1/extracurricular/events/99')
       })
     })
+  })
+})
+
+describe('useExtracurricularEvents hooks (mutations)', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  describe('createExtracurricularEvent', () => {
+    it('POSTs to /api/v1/extracurricular/events with payload', async () => {
+      mockedApiClient.post.mockResolvedValue({ data: { id: 1, title: 'X' } })
+      const result = await createExtracurricularEvent({
+        title: 'X',
+        category: 'academic',
+        target_audience: 'students',
+        start_at: '2026-06-01T10:00:00Z',
+        end_at: '2026-06-01T12:00:00Z',
+      })
+      expect(mockedApiClient.post).toHaveBeenCalledWith(
+        '/api/v1/extracurricular/events',
+        expect.objectContaining({ title: 'X', category: 'academic' })
+      )
+      expect(result.id).toBe(1)
+    })
+  })
+
+  describe('updateExtracurricularEvent', () => {
+    it('PUTs to /api/v1/extracurricular/events/:id with payload', async () => {
+      mockedApiClient.put.mockResolvedValue({ data: { id: 5, title: 'New' } })
+      const result = await updateExtracurricularEvent(5, {
+        title: 'New',
+        category: 'cultural',
+        target_audience: 'all',
+        start_at: '2026-06-01T10:00:00Z',
+        end_at: '2026-06-01T12:00:00Z',
+      })
+      expect(mockedApiClient.put).toHaveBeenCalledWith(
+        '/api/v1/extracurricular/events/5',
+        expect.objectContaining({ title: 'New' })
+      )
+      expect(result.id).toBe(5)
+    })
+  })
+
+  describe('deleteExtracurricularEvent', () => {
+    it('DELETEs /api/v1/extracurricular/events/:id', async () => {
+      mockedApiClient.delete.mockResolvedValue(undefined)
+      await deleteExtracurricularEvent(9)
+      expect(mockedApiClient.delete).toHaveBeenCalledWith('/api/v1/extracurricular/events/9')
+    })
+  })
+
+  describe('registerForExtracurricularEvent', () => {
+    it('POSTs to /:id/register', async () => {
+      mockedApiClient.post.mockResolvedValue(undefined)
+      await registerForExtracurricularEvent(3)
+      expect(mockedApiClient.post).toHaveBeenCalledWith('/api/v1/extracurricular/events/3/register')
+    })
+  })
+
+  describe('unregisterFromExtracurricularEvent', () => {
+    it('DELETEs /:id/register', async () => {
+      mockedApiClient.delete.mockResolvedValue(undefined)
+      await unregisterFromExtracurricularEvent(3)
+      expect(mockedApiClient.delete).toHaveBeenCalledWith(
+        '/api/v1/extracurricular/events/3/register'
+      )
+    })
+  })
+})
+
+describe('pickExtracurricularErrorKey', () => {
+  // Table-driven per CLAUDE.md ≥3-variant gate.
+  type Row = {
+    name: string
+    err: unknown
+    expected: string
+  }
+
+  const mkErr = (status?: number, code?: string) => ({
+    response: {
+      status,
+      data: code ? { error: { code, message: 'x' } } : undefined,
+    },
+  })
+
+  const cases: Row[] = [
+    {
+      name: 'VERSION_CONFLICT code → versionConflict',
+      err: mkErr(409, 'VERSION_CONFLICT'),
+      expected: 'versionConflict',
+    },
+    {
+      name: 'ALREADY_REGISTERED → alreadyRegistered',
+      err: mkErr(409, 'ALREADY_REGISTERED'),
+      expected: 'alreadyRegistered',
+    },
+    {
+      name: 'EVENT_FULL → eventFull',
+      err: mkErr(409, 'EVENT_FULL'),
+      expected: 'eventFull',
+    },
+    {
+      name: 'REGISTRATION_CLOSED → registrationClosed',
+      err: mkErr(422, 'REGISTRATION_CLOSED'),
+      expected: 'registrationClosed',
+    },
+    {
+      name: 'CANNOT_EDIT → cannotEdit',
+      err: mkErr(422, 'CANNOT_EDIT'),
+      expected: 'cannotEdit',
+    },
+    {
+      name: 'INVALID_EVENT → invalidEvent',
+      err: mkErr(422, 'INVALID_EVENT'),
+      expected: 'invalidEvent',
+    },
+    {
+      name: 'plain 403 (no code) → forbidden',
+      err: mkErr(403),
+      expected: 'forbidden',
+    },
+    {
+      name: 'plain 404 (no code) → notFound',
+      err: mkErr(404),
+      expected: 'notFound',
+    },
+    {
+      name: 'unknown 500 → generic',
+      err: mkErr(500),
+      expected: 'generic',
+    },
+    {
+      name: 'undefined error → generic (safe fallback)',
+      err: undefined,
+      expected: 'generic',
+    },
+  ]
+
+  it.each(cases)('$name', ({ err, expected }) => {
+    expect(pickExtracurricularErrorKey(err)).toBe(expected)
   })
 })

--- a/frontend/src/hooks/useExtracurricularEvents.ts
+++ b/frontend/src/hooks/useExtracurricularEvents.ts
@@ -111,3 +111,9 @@ export async function unregisterFromExtracurricularEvent(_id: number): Promise<v
   void _id
   throw NOT_IMPL
 }
+
+// Pair 2 stub — table-driven mapping in next GREEN.
+export function pickExtracurricularErrorKey(_err: unknown): string {
+  void _err
+  return 'unstubbed'
+}

--- a/frontend/src/hooks/useExtracurricularEvents.ts
+++ b/frontend/src/hooks/useExtracurricularEvents.ts
@@ -1,0 +1,76 @@
+'use client'
+
+// Extracurricular events SWR hooks + mutation actions.
+// Mirrors useAnnouncements pattern; talks to /api/v1/extracurricular/events
+// (see internal/modules/extracurricular/interfaces/http/handlers).
+
+import useSWR from 'swr'
+import { apiClient } from '@/lib/api'
+import { SWR_DEDUPING } from '@/config/swr'
+import type {
+  ExtracurricularEvent,
+  ExtracurricularEventListResponse,
+  ExtracurricularEventFilterParams,
+  CreateExtracurricularEventInput,
+  UpdateExtracurricularEventInput,
+} from '@/types/extracurricular'
+
+// Stub implementations — replaced in GREEN commit. RED commit ships
+// these to keep eslint happy (resolvable imports) while tests fail
+// on assertion (per project pre-commit-friendly RED pattern).
+const NOT_IMPL = new Error('extracurricular hook stub — not implemented')
+
+export function useExtracurricularEvents(_params?: ExtracurricularEventFilterParams) {
+  void _params
+  void useSWR
+  void apiClient
+  void SWR_DEDUPING
+  return {
+    events: [] as ExtracurricularEventListResponse['items'],
+    total: 0,
+    isLoading: false,
+    error: undefined as Error | undefined,
+    mutate: async () => undefined,
+  }
+}
+
+export function useExtracurricularEvent(_id: number | null) {
+  void _id
+  return {
+    event: undefined as ExtracurricularEvent | undefined,
+    isLoading: false,
+    error: undefined as Error | undefined,
+    mutate: async () => undefined,
+  }
+}
+
+export async function createExtracurricularEvent(
+  _input: CreateExtracurricularEventInput
+): Promise<ExtracurricularEvent> {
+  void _input
+  throw NOT_IMPL
+}
+
+export async function updateExtracurricularEvent(
+  _id: number,
+  _input: UpdateExtracurricularEventInput
+): Promise<ExtracurricularEvent> {
+  void _id
+  void _input
+  throw NOT_IMPL
+}
+
+export async function deleteExtracurricularEvent(_id: number): Promise<void> {
+  void _id
+  throw NOT_IMPL
+}
+
+export async function registerForExtracurricularEvent(_id: number): Promise<void> {
+  void _id
+  throw NOT_IMPL
+}
+
+export async function unregisterFromExtracurricularEvent(_id: number): Promise<void> {
+  void _id
+  throw NOT_IMPL
+}

--- a/frontend/src/hooks/useExtracurricularEvents.ts
+++ b/frontend/src/hooks/useExtracurricularEvents.ts
@@ -15,34 +15,71 @@ import type {
   UpdateExtracurricularEventInput,
 } from '@/types/extracurricular'
 
-// Stub implementations — replaced in GREEN commit. RED commit ships
-// these to keep eslint happy (resolvable imports) while tests fail
-// on assertion (per project pre-commit-friendly RED pattern).
-const NOT_IMPL = new Error('extracurricular hook stub — not implemented')
+const BASE_URL = '/api/v1/extracurricular/events'
 
-export function useExtracurricularEvents(_params?: ExtracurricularEventFilterParams) {
-  void _params
-  void useSWR
-  void apiClient
-  void SWR_DEDUPING
+interface ApiResponse<T> {
+  success: boolean
+  data: T
+  error?: { code: string; message: string }
+  meta?: { request_id: string; timestamp: string; version: string }
+}
+
+const fetcher = async <T>(url: string): Promise<T> => {
+  const response = await apiClient.get<ApiResponse<T>>(url)
+  return response.data
+}
+
+// useExtracurricularEvents fetches a paginated, audience-filtered list.
+// Server applies CanViewEvent matrix per actor role — pass filter
+// params to narrow further (status/category/date range/organizer).
+export function useExtracurricularEvents(params?: ExtracurricularEventFilterParams) {
+  const searchParams = new URLSearchParams()
+  if (params) {
+    Object.entries(params).forEach(([key, value]) => {
+      if (value === undefined || value === null) return
+      searchParams.append(key, String(value))
+    })
+  }
+
+  const queryString = searchParams.toString()
+  const url = queryString ? `${BASE_URL}?${queryString}` : BASE_URL
+
+  const { data, error, isLoading, mutate } = useSWR<ExtracurricularEventListResponse>(
+    url,
+    fetcher,
+    {
+      revalidateOnFocus: false,
+      dedupingInterval: SWR_DEDUPING.SHORT,
+    }
+  )
+
   return {
-    events: [] as ExtracurricularEventListResponse['items'],
-    total: 0,
-    isLoading: false,
-    error: undefined as Error | undefined,
-    mutate: async () => undefined,
+    events: data?.items || [],
+    total: data?.total || 0,
+    isLoading,
+    error,
+    mutate,
   }
 }
 
-export function useExtracurricularEvent(_id: number | null) {
-  void _id
+// useExtracurricularEvent fetches one event by id. Pass null to skip.
+export function useExtracurricularEvent(id: number | null) {
+  const { data, error, isLoading, mutate } = useSWR<ExtracurricularEvent>(
+    id ? `${BASE_URL}/${id}` : null,
+    fetcher
+  )
+
   return {
-    event: undefined as ExtracurricularEvent | undefined,
-    isLoading: false,
-    error: undefined as Error | undefined,
-    mutate: async () => undefined,
+    event: data,
+    isLoading,
+    error,
+    mutate,
   }
 }
+
+// === Mutations (Pair 2 — stubs until next GREEN) ===
+
+const NOT_IMPL = new Error('extracurricular mutation stub — not implemented')
 
 export async function createExtracurricularEvent(
   _input: CreateExtracurricularEventInput

--- a/frontend/src/hooks/useExtracurricularEvents.ts
+++ b/frontend/src/hooks/useExtracurricularEvents.ts
@@ -77,43 +77,60 @@ export function useExtracurricularEvent(id: number | null) {
   }
 }
 
-// === Mutations (Pair 2 — stubs until next GREEN) ===
-
-const NOT_IMPL = new Error('extracurricular mutation stub — not implemented')
+// === Mutations ===
 
 export async function createExtracurricularEvent(
-  _input: CreateExtracurricularEventInput
+  input: CreateExtracurricularEventInput
 ): Promise<ExtracurricularEvent> {
-  void _input
-  throw NOT_IMPL
+  const wrapper = await apiClient.post<ApiResponse<ExtracurricularEvent>>(BASE_URL, input)
+  return wrapper.data
 }
 
 export async function updateExtracurricularEvent(
-  _id: number,
-  _input: UpdateExtracurricularEventInput
+  id: number,
+  input: UpdateExtracurricularEventInput
 ): Promise<ExtracurricularEvent> {
-  void _id
-  void _input
-  throw NOT_IMPL
+  const wrapper = await apiClient.put<ApiResponse<ExtracurricularEvent>>(`${BASE_URL}/${id}`, input)
+  return wrapper.data
 }
 
-export async function deleteExtracurricularEvent(_id: number): Promise<void> {
-  void _id
-  throw NOT_IMPL
+export async function deleteExtracurricularEvent(id: number): Promise<void> {
+  await apiClient.delete(`${BASE_URL}/${id}`)
 }
 
-export async function registerForExtracurricularEvent(_id: number): Promise<void> {
-  void _id
-  throw NOT_IMPL
+export async function registerForExtracurricularEvent(id: number): Promise<void> {
+  await apiClient.post(`${BASE_URL}/${id}/register`)
 }
 
-export async function unregisterFromExtracurricularEvent(_id: number): Promise<void> {
-  void _id
-  throw NOT_IMPL
+export async function unregisterFromExtracurricularEvent(id: number): Promise<void> {
+  await apiClient.delete(`${BASE_URL}/${id}/register`)
 }
 
-// Pair 2 stub — table-driven mapping in next GREEN.
-export function pickExtracurricularErrorKey(_err: unknown): string {
-  void _err
-  return 'unstubbed'
+// === Error mapping ===
+//
+// Translates backend sentinel codes (see mapEventError in
+// event_handler.go) to camelCase i18n keys under the
+// extracurricular.errors.* namespace. Status-aware fallback for
+// codes the backend omits (plain 403 / 404 / 5xx).
+
+const ERROR_CODE_MAP: Record<string, string> = {
+  VERSION_CONFLICT: 'versionConflict',
+  ALREADY_REGISTERED: 'alreadyRegistered',
+  EVENT_FULL: 'eventFull',
+  REGISTRATION_CLOSED: 'registrationClosed',
+  CANNOT_EDIT: 'cannotEdit',
+  INVALID_EVENT: 'invalidEvent',
+}
+
+export function pickExtracurricularErrorKey(err: unknown): string {
+  if (!err) return 'generic'
+  const e = err as {
+    response?: { status?: number; data?: { error?: { code?: string } } }
+  }
+  const code = e.response?.data?.error?.code
+  if (code && ERROR_CODE_MAP[code]) return ERROR_CODE_MAP[code]
+  const status = e.response?.status
+  if (status === 403) return 'forbidden'
+  if (status === 404) return 'notFound'
+  return 'generic'
 }

--- a/frontend/src/types/extracurricular.ts
+++ b/frontend/src/types/extracurricular.ts
@@ -1,0 +1,130 @@
+// Extracurricular event types mirroring backend DTO at
+// internal/modules/extracurricular/interfaces/http/handlers/event_handler.go
+// (EventDTO / EventSummaryDTO / CreateEventRequest / UpdateEventRequest).
+// Sentinel error codes mirror handler mapEventError.
+
+export type EventStatus = 'draft' | 'published' | 'canceled' | 'completed'
+
+export type EventCategory = 'academic' | 'cultural' | 'sports' | 'volunteer' | 'professional'
+
+export type EventTargetAudience = 'all' | 'students' | 'teachers' | 'staff'
+
+export const EVENT_STATUSES: EventStatus[] = ['draft', 'published', 'canceled', 'completed']
+
+export const EVENT_CATEGORIES: EventCategory[] = [
+  'academic',
+  'cultural',
+  'sports',
+  'volunteer',
+  'professional',
+]
+
+export const EVENT_TARGET_AUDIENCES: EventTargetAudience[] = [
+  'all',
+  'students',
+  'teachers',
+  'staff',
+]
+
+export interface ExtracurricularParticipant {
+  user_id: number
+  registered_at: string
+}
+
+export interface ExtracurricularEvent {
+  id: number
+  title: string
+  description: string
+  category: EventCategory
+  target_audience: EventTargetAudience
+  status: EventStatus
+  location: string
+  start_at: string
+  end_at: string
+  max_capacity?: number | null
+  organizer_id: number
+  participants?: ExtracurricularParticipant[]
+  participant_count: number
+  version: number
+  created_at: string
+  updated_at: string
+}
+
+export interface ExtracurricularEventSummary {
+  id: number
+  title: string
+  category: EventCategory
+  target_audience: EventTargetAudience
+  status: EventStatus
+  location: string
+  start_at: string
+  end_at: string
+  max_capacity?: number | null
+  organizer_id: number
+  participant_count: number
+  version: number
+  created_at: string
+  updated_at: string
+}
+
+export interface ExtracurricularEventListResponse {
+  items: ExtracurricularEventSummary[]
+  total: number
+}
+
+export interface ExtracurricularEventFilterParams {
+  status?: EventStatus
+  category?: EventCategory
+  organizer_id?: number
+  from?: string
+  to?: string
+  limit?: number
+  offset?: number
+}
+
+export interface CreateExtracurricularEventInput {
+  title: string
+  description?: string
+  category: EventCategory
+  target_audience: EventTargetAudience
+  location?: string
+  start_at: string
+  end_at: string
+  max_capacity?: number | null
+}
+
+export interface UpdateExtracurricularEventInput {
+  title: string
+  description?: string
+  category: EventCategory
+  target_audience: EventTargetAudience
+  location?: string
+  start_at: string
+  end_at: string
+  max_capacity?: number | null
+}
+
+// Sentinel error codes mirrored from backend handler mapEventError.
+// Frontend maps these via pickErrorKey to i18n strings.
+export type ExtracurricularErrorCode =
+  | 'VERSION_CONFLICT'
+  | 'INVALID_EVENT'
+  | 'ALREADY_REGISTERED'
+  | 'EVENT_FULL'
+  | 'REGISTRATION_CLOSED'
+  | 'CANNOT_EDIT'
+  | 'FORBIDDEN'
+  | 'NOT_FOUND'
+  | 'GENERIC'
+
+export const EXTRACURRICULAR_ERROR_CODES: ExtracurricularErrorCode[] = [
+  'VERSION_CONFLICT',
+  'INVALID_EVENT',
+  'ALREADY_REGISTERED',
+  'EVENT_FULL',
+  'REGISTRATION_CLOSED',
+  'CANNOT_EDIT',
+  'FORBIDDEN',
+  'NOT_FOUND',
+  'GENERIC',
+]


### PR DESCRIPTION
## Scope — v0.165.0 foundation, split half 1

Part of B3 Extracurricular frontend slice (#328). Backend shipped в v0.162.0 → v0.164.0 series.

PR-1 split into 2 halves to stay under PR-Size 1000 LOC gate. This is **half 1** (hooks + types, 588 LOC). Half 2 (i18n × 4 parity + 4 locale namespaces) lands в next PR.

## Deliverables

**Types** в `frontend/src/types/extracurricular.ts` (130 LOC) — mirror backend DTO shapes (`EventDTO`, `EventSummaryDTO`, `CreateEventRequest`, `UpdateEventRequest`) + sentinel error codes + canonical enum arrays.

**SWR hooks** в `frontend/src/hooks/useExtracurricularEvents.ts` (136 LOC):
- `useExtracurricularEvents(filter)` — paginated list с URL-encoded filter params
- `useExtracurricularEvent(id)` — single event by id
- 5 mutations: `create / update / delete / register / unregister`
- `pickExtracurricularErrorKey` — translates backend sentinel codes (`VERSION_CONFLICT`, `ALREADY_REGISTERED`, `EVENT_FULL`, `REGISTRATION_CLOSED`, `CANNOT_EDIT`, `INVALID_EVENT`) to camelCase i18n keys, with status-aware fallback (403 → forbidden, 404 → notFound, unknown → generic)

**Tests** (322 LOC) — 22/22 pass:
- 7 query hook tests (list filtering, detail, null-id guard, canonical URL)
- 5 mutation tests (URL + method + payload shape)
- 10 table-driven `pickExtracurricularErrorKey` cases per CLAUDE.md ≥3-variant gate

## TDD discipline

2 pairs RED → GREEN:
- Pair 1 RED `3636732a` → GREEN `3be1845b` — query hooks
- Pair 2 RED `57f86426` → GREEN `080d58b5` — mutations + pickErrorKey

## Definition of done (for this PR)

- [x] `npm test -- --testPathPattern=extracurricular` 22/22 green
- [x] `prettier --check` clean
- [x] `eslint` clean
- [x] Pre-commit hook clean (no --no-verify)
- [x] 588 LOC < 1000 PR-Size gate

## Next

PR-1b (i18n × 4 parity test + ru/en/fr/ar `extracurricular` namespace, ~528 LOC) → PR-2 (pages) → PR-3 (widget + nav + notifications wiring + release v0.165.0).

Refs #328