### PR TITLE
feat(extracurricular): v0.165.0c1 — EventCard + Filters + list page

### DIFF
--- a/frontend/src/app/extracurricular/__tests__/page.test.tsx
+++ b/frontend/src/app/extracurricular/__tests__/page.test.tsx
@@ -1,0 +1,141 @@
+import { render, screen } from '@testing-library/react'
+
+const mockReplace = jest.fn()
+const mockPush = jest.fn()
+jest.mock('next/navigation', () => ({
+  useRouter: () => ({ replace: mockReplace, push: mockPush }),
+  useParams: () => ({}),
+}))
+
+const mockUseAuthCheck = jest.fn()
+jest.mock('@/hooks/useAuth', () => ({
+  useAuthCheck: () => mockUseAuthCheck(),
+}))
+
+const mockUserStore = jest.fn()
+jest.mock('@/stores/authStore', () => ({
+  useAuthStore: (selector: (s: { user: { id: number; role: string } | null }) => unknown) =>
+    selector({ user: mockUserStore() }),
+}))
+
+jest.mock('@/components/layout', () => ({
+  AppLayout: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+}))
+
+const mockUseEvents = jest.fn()
+jest.mock('@/hooks/useExtracurricularEvents', () => ({
+  useExtracurricularEvents: (filter?: unknown) => mockUseEvents(filter),
+  useExtracurricularEvent: jest.fn(),
+  createExtracurricularEvent: jest.fn(),
+  updateExtracurricularEvent: jest.fn(),
+  deleteExtracurricularEvent: jest.fn(),
+  registerForExtracurricularEvent: jest.fn(),
+  unregisterFromExtracurricularEvent: jest.fn(),
+  pickExtracurricularErrorKey: () => 'generic',
+}))
+
+import ExtracurricularEventsPage from '../page'
+
+const academicSecretaryAuth = {
+  user: { id: 5, role: 'academic_secretary' as const },
+  isAuthenticated: true,
+  isLoading: false,
+}
+
+const studentAuth = {
+  user: { id: 9, role: 'student' as const },
+  isAuthenticated: true,
+  isLoading: false,
+}
+
+beforeEach(() => {
+  mockReplace.mockClear()
+  mockPush.mockClear()
+  mockUseAuthCheck.mockReturnValue(academicSecretaryAuth)
+  mockUserStore.mockReturnValue(academicSecretaryAuth.user)
+  mockUseEvents.mockReturnValue({
+    events: [],
+    total: 0,
+    isLoading: false,
+    error: undefined,
+    mutate: jest.fn(),
+  })
+})
+
+describe('ExtracurricularEventsPage', () => {
+  it('renders the page title', () => {
+    render(<ExtracurricularEventsPage />)
+    expect(screen.getByText('title')).toBeInTheDocument()
+  })
+
+  it('renders create button for non-student roles', () => {
+    render(<ExtracurricularEventsPage />)
+    expect(screen.getByText('create')).toBeInTheDocument()
+  })
+
+  it('hides create button for student role', () => {
+    mockUseAuthCheck.mockReturnValue(studentAuth)
+    mockUserStore.mockReturnValue(studentAuth.user)
+    render(<ExtracurricularEventsPage />)
+    expect(screen.queryByText('create')).not.toBeInTheDocument()
+  })
+
+  it('shows empty state when no events', () => {
+    render(<ExtracurricularEventsPage />)
+    expect(screen.getByText('empty')).toBeInTheDocument()
+  })
+
+  it('renders event cards when events present', () => {
+    mockUseEvents.mockReturnValue({
+      events: [
+        {
+          id: 1,
+          title: 'Hackathon 2026',
+          category: 'academic',
+          target_audience: 'students',
+          status: 'published',
+          location: 'Lab 3',
+          start_at: '2026-06-15T10:00:00Z',
+          end_at: '2026-06-15T18:00:00Z',
+          max_capacity: 30,
+          organizer_id: 5,
+          participant_count: 12,
+          version: 1,
+          created_at: '2026-05-20T10:00:00Z',
+          updated_at: '2026-05-20T10:00:00Z',
+        },
+      ],
+      total: 1,
+      isLoading: false,
+      error: undefined,
+      mutate: jest.fn(),
+    })
+    render(<ExtracurricularEventsPage />)
+    expect(screen.getByText('Hackathon 2026')).toBeInTheDocument()
+  })
+
+  it('shows loading spinner when isLoading', () => {
+    mockUseEvents.mockReturnValue({
+      events: [],
+      total: 0,
+      isLoading: true,
+      error: undefined,
+      mutate: jest.fn(),
+    })
+    const { container } = render(<ExtracurricularEventsPage />)
+    // Lucide Loader2 sets svg with animate-spin class.
+    expect(container.querySelector('.animate-spin')).toBeInTheDocument()
+  })
+
+  it('shows error state on load failure', () => {
+    mockUseEvents.mockReturnValue({
+      events: [],
+      total: 0,
+      isLoading: false,
+      error: new Error('boom'),
+      mutate: jest.fn(),
+    })
+    render(<ExtracurricularEventsPage />)
+    expect(screen.getByText('loadFailed')).toBeInTheDocument()
+  })
+})

--- a/frontend/src/app/extracurricular/page.tsx
+++ b/frontend/src/app/extracurricular/page.tsx
@@ -1,0 +1,6 @@
+'use client'
+
+// Stub — replaced in GREEN.
+export default function ExtracurricularEventsPage() {
+  return null
+}

--- a/frontend/src/app/extracurricular/page.tsx
+++ b/frontend/src/app/extracurricular/page.tsx
@@ -1,6 +1,81 @@
 'use client'
 
-// Stub — replaced in GREEN.
+import { useState } from 'react'
+import { useRouter } from 'next/navigation'
+import { useTranslations } from 'next-intl'
+import { Calendar, Loader2, Plus } from 'lucide-react'
+
+import { AppLayout } from '@/components/layout'
+import { Button } from '@/components/ui/button'
+import { ExtracurricularEventCard } from '@/components/extracurricular/ExtracurricularEventCard'
+import { ExtracurricularEventFilters } from '@/components/extracurricular/ExtracurricularEventFilters'
+import { useExtracurricularEvents } from '@/hooks/useExtracurricularEvents'
+import type { ExtracurricularEventFilterParams } from '@/types/extracurricular'
+import { useAuthCheck } from '@/hooks/useAuth'
+import { useAuthStore } from '@/stores/authStore'
+
+// Edit roles per CLAUDE.md role matrix: all except student can author/edit
+// events. Backend authz mirror — see ext authz.go AuthorizeEventCreate.
+function canCreateEvents(role: string | undefined): boolean {
+  return role !== undefined && role !== 'student'
+}
+
 export default function ExtracurricularEventsPage() {
-  return null
+  const t = useTranslations('extracurricular')
+  useAuthCheck()
+  const user = useAuthStore((s) => s.user)
+  const userCanCreate = canCreateEvents(user?.role)
+  const router = useRouter()
+
+  const [filters, setFilters] = useState<ExtracurricularEventFilterParams>({})
+  const { events, isLoading, error } = useExtracurricularEvents(filters)
+
+  return (
+    <AppLayout>
+      <div className="mx-auto max-w-6xl space-y-6 p-4 md:p-6">
+        <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4">
+          <div className="flex items-center gap-2">
+            <Calendar className="h-6 w-6" />
+            <div>
+              <h1 className="text-2xl font-bold">{t('title')}</h1>
+              <p className="text-sm text-muted-foreground">{t('description')}</p>
+            </div>
+          </div>
+          {userCanCreate && (
+            <Button onClick={() => router.push('/extracurricular/new')}>
+              <Plus className="h-4 w-4 mr-2" />
+              {t('create')}
+            </Button>
+          )}
+        </div>
+
+        <ExtracurricularEventFilters value={filters} onChange={setFilters} />
+
+        {isLoading ? (
+          <div className="flex items-center justify-center py-16">
+            <Loader2 className="h-8 w-8 animate-spin text-muted-foreground" />
+          </div>
+        ) : error ? (
+          <div className="rounded-xl bg-card border border-border p-8 text-center">
+            <p className="text-destructive font-medium">{t('loadFailed')}</p>
+          </div>
+        ) : events.length === 0 ? (
+          <div className="flex flex-col items-center justify-center py-16 text-center">
+            <Calendar className="h-16 w-16 text-muted-foreground/30 mb-4" />
+            <p className="text-lg font-medium">{t('empty')}</p>
+          </div>
+        ) : (
+          <div className="grid gap-3">
+            {events.map((event) => (
+              <ExtracurricularEventCard
+                key={event.id}
+                event={event}
+                onClick={() => router.push(`/extracurricular/${event.id}`)}
+              />
+            ))}
+          </div>
+        )}
+      </div>
+    </AppLayout>
+  )
 }

--- a/frontend/src/components/extracurricular/ExtracurricularEventCard.tsx
+++ b/frontend/src/components/extracurricular/ExtracurricularEventCard.tsx
@@ -1,0 +1,26 @@
+'use client'
+
+// Stub — replaced in GREEN. Tests assert rendering of title, status
+// badge, category badge, audience badge, date, location, capacity,
+// and dropdown actions.
+
+import type { ExtracurricularEventSummary } from '@/types/extracurricular'
+
+export interface ExtracurricularEventCardProps {
+  event: ExtracurricularEventSummary
+  onClick?: () => void
+  onEdit?: () => void
+  onDelete?: () => void
+  onRegister?: () => void
+  onUnregister?: () => void
+  onPublish?: () => void
+  onCancel?: () => void
+  onComplete?: () => void
+  isRegistered?: boolean
+  className?: string
+}
+
+export function ExtracurricularEventCard(_props: ExtracurricularEventCardProps) {
+  void _props
+  return null
+}

--- a/frontend/src/components/extracurricular/ExtracurricularEventCard.tsx
+++ b/frontend/src/components/extracurricular/ExtracurricularEventCard.tsx
@@ -1,10 +1,37 @@
 'use client'
 
-// Stub — replaced in GREEN. Tests assert rendering of title, status
-// badge, category badge, audience badge, date, location, capacity,
-// and dropdown actions.
+import { format } from 'date-fns'
+import { ru, enUS, fr, ar } from 'date-fns/locale'
+import {
+  MapPin,
+  Calendar as CalendarIcon,
+  Users,
+  MoreHorizontal,
+  Send,
+  X as XIcon,
+  CheckCircle,
+  Edit,
+  Trash2,
+} from 'lucide-react'
+import { useTranslations, useLocale } from 'next-intl'
 
-import type { ExtracurricularEventSummary } from '@/types/extracurricular'
+import { cn } from '@/lib/utils'
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from '@/components/ui/dropdown-menu'
+import { Button } from '@/components/ui/button'
+import type {
+  EventCategory,
+  EventStatus,
+  EventTargetAudience,
+  ExtracurricularEventSummary,
+} from '@/types/extracurricular'
+
+const localeMap = { ru, en: enUS, fr, ar }
 
 export interface ExtracurricularEventCardProps {
   event: ExtracurricularEventSummary
@@ -20,7 +47,182 @@ export interface ExtracurricularEventCardProps {
   className?: string
 }
 
-export function ExtracurricularEventCard(_props: ExtracurricularEventCardProps) {
-  void _props
-  return null
+const STATUS_COLORS: Record<EventStatus, string> = {
+  draft: 'bg-slate-100 text-slate-700 dark:bg-slate-800 dark:text-slate-300',
+  published: 'bg-emerald-100 text-emerald-700 dark:bg-emerald-900/40 dark:text-emerald-300',
+  canceled: 'bg-rose-100 text-rose-700 dark:bg-rose-900/40 dark:text-rose-300',
+  completed: 'bg-gray-100 text-gray-500 dark:bg-gray-900/40 dark:text-gray-400',
+}
+
+const CATEGORY_COLORS: Record<EventCategory, string> = {
+  academic: 'bg-blue-100 text-blue-700 dark:bg-blue-900/40 dark:text-blue-300',
+  cultural: 'bg-violet-100 text-violet-700 dark:bg-violet-900/40 dark:text-violet-300',
+  sports: 'bg-emerald-100 text-emerald-700 dark:bg-emerald-900/40 dark:text-emerald-300',
+  volunteer: 'bg-amber-100 text-amber-700 dark:bg-amber-900/40 dark:text-amber-300',
+  professional: 'bg-cyan-100 text-cyan-700 dark:bg-cyan-900/40 dark:text-cyan-300',
+}
+
+const AUDIENCE_COLORS: Record<EventTargetAudience, string> = {
+  all: 'bg-violet-100 text-violet-700 dark:bg-violet-900/40 dark:text-violet-300',
+  students: 'bg-blue-100 text-blue-700 dark:bg-blue-900/40 dark:text-blue-300',
+  teachers: 'bg-amber-100 text-amber-700 dark:bg-amber-900/40 dark:text-amber-300',
+  staff: 'bg-cyan-100 text-cyan-700 dark:bg-cyan-900/40 dark:text-cyan-300',
+}
+
+export function ExtracurricularEventCard({
+  event,
+  onClick,
+  onEdit,
+  onDelete,
+  onRegister,
+  onUnregister,
+  onPublish,
+  onCancel,
+  onComplete,
+  isRegistered,
+  className,
+}: ExtracurricularEventCardProps) {
+  const t = useTranslations('extracurricular')
+  const locale = useLocale()
+  const dateLocale = localeMap[locale as keyof typeof localeMap] || enUS
+
+  const hasMenu = Boolean(onEdit || onDelete || onPublish || onCancel || onComplete)
+
+  return (
+    <div
+      className={cn(
+        'group relative rounded-xl border border-gray-100 dark:border-gray-800 p-4',
+        'transition-all duration-200 ease-out hover:shadow-md',
+        'bg-white dark:bg-gray-950/40',
+        className
+      )}
+    >
+      <div className="flex items-start justify-between gap-2">
+        <div className="flex-1 min-w-0">
+          <div className="flex items-center gap-2 mb-2 flex-wrap">
+            <span
+              className={cn(
+                'text-[10px] font-semibold uppercase tracking-wide px-2 py-0.5 rounded-full',
+                STATUS_COLORS[event.status]
+              )}
+            >
+              {t(`status.${event.status}`)}
+            </span>
+            <span
+              className={cn(
+                'text-[10px] font-semibold uppercase tracking-wide px-2 py-0.5 rounded-full',
+                CATEGORY_COLORS[event.category]
+              )}
+            >
+              {t(`category.${event.category}`)}
+            </span>
+            <span
+              className={cn(
+                'text-[10px] font-semibold uppercase tracking-wide px-2 py-0.5 rounded-full',
+                AUDIENCE_COLORS[event.target_audience]
+              )}
+            >
+              {t(`audience.${event.target_audience}`)}
+            </span>
+          </div>
+
+          <button
+            onClick={onClick}
+            className="text-base font-semibold hover:underline text-left w-full truncate text-gray-900 dark:text-gray-100"
+          >
+            {event.title}
+          </button>
+
+          <div className="mt-2 flex items-center gap-3 flex-wrap text-xs text-muted-foreground">
+            {event.location && (
+              <div className="flex items-center gap-1.5">
+                <MapPin className="h-3.5 w-3.5" />
+                <span className="truncate">{event.location}</span>
+              </div>
+            )}
+            <div className="flex items-center gap-1.5">
+              <CalendarIcon className="h-3.5 w-3.5" />
+              <span>
+                {format(new Date(event.start_at), 'd MMM yyyy HH:mm', { locale: dateLocale })}
+              </span>
+            </div>
+            <div className="flex items-center gap-1.5">
+              <Users className="h-3.5 w-3.5" />
+              <span>
+                {event.max_capacity != null
+                  ? `${event.participant_count} / ${event.max_capacity}`
+                  : `${event.participant_count}`}
+              </span>
+            </div>
+          </div>
+        </div>
+
+        {hasMenu && (
+          <DropdownMenu>
+            <DropdownMenuTrigger asChild>
+              <Button
+                data-testid="event-card-menu-trigger"
+                variant="ghost"
+                size="icon"
+                className="h-8 w-8 shrink-0 opacity-0 group-hover:opacity-100 transition-opacity"
+              >
+                <MoreHorizontal className="h-4 w-4" />
+              </Button>
+            </DropdownMenuTrigger>
+            <DropdownMenuContent align="end">
+              {onEdit && (
+                <DropdownMenuItem onClick={onEdit}>
+                  <Edit className="h-4 w-4 mr-2" />
+                  {t('edit')}
+                </DropdownMenuItem>
+              )}
+              {event.status === 'draft' && onPublish && (
+                <DropdownMenuItem onClick={onPublish}>
+                  <Send className="h-4 w-4 mr-2" />
+                  {t('actions.publish')}
+                </DropdownMenuItem>
+              )}
+              {event.status === 'published' && onCancel && (
+                <DropdownMenuItem onClick={onCancel}>
+                  <XIcon className="h-4 w-4 mr-2" />
+                  {t('actions.cancel')}
+                </DropdownMenuItem>
+              )}
+              {event.status === 'published' && onComplete && (
+                <DropdownMenuItem onClick={onComplete}>
+                  <CheckCircle className="h-4 w-4 mr-2" />
+                  {t('actions.complete')}
+                </DropdownMenuItem>
+              )}
+              {onDelete && (
+                <>
+                  <DropdownMenuSeparator />
+                  <DropdownMenuItem onClick={onDelete} className="text-destructive">
+                    <Trash2 className="h-4 w-4 mr-2" />
+                    {t('delete')}
+                  </DropdownMenuItem>
+                </>
+              )}
+            </DropdownMenuContent>
+          </DropdownMenu>
+        )}
+      </div>
+
+      {(onRegister || onUnregister) && (
+        <div className="mt-3 flex justify-end">
+          {isRegistered
+            ? onUnregister && (
+                <Button variant="outline" size="sm" onClick={onUnregister}>
+                  {t('unregister')}
+                </Button>
+              )
+            : onRegister && (
+                <Button size="sm" onClick={onRegister}>
+                  {t('register')}
+                </Button>
+              )}
+        </div>
+      )}
+    </div>
+  )
 }

--- a/frontend/src/components/extracurricular/ExtracurricularEventFilters.tsx
+++ b/frontend/src/components/extracurricular/ExtracurricularEventFilters.tsx
@@ -1,15 +1,94 @@
 'use client'
 
-// Stub — replaced in GREEN.
+import { useTranslations } from 'next-intl'
 
-import type { ExtracurricularEventFilterParams } from '@/types/extracurricular'
+import { cn } from '@/lib/utils'
+import {
+  EVENT_STATUSES,
+  EVENT_CATEGORIES,
+  type ExtracurricularEventFilterParams,
+  type EventStatus,
+  type EventCategory,
+} from '@/types/extracurricular'
 
 export interface ExtracurricularEventFiltersProps {
   value: ExtracurricularEventFilterParams
   onChange: (next: ExtracurricularEventFilterParams) => void
+  className?: string
 }
 
-export function ExtracurricularEventFilters(_props: ExtracurricularEventFiltersProps) {
-  void _props
-  return null
+const SELECT_CLASS =
+  'flex h-10 w-full items-center justify-between rounded-md border border-input bg-background px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-ring'
+
+export function ExtracurricularEventFilters({
+  value,
+  onChange,
+  className,
+}: ExtracurricularEventFiltersProps) {
+  const t = useTranslations('extracurricular')
+
+  // Apply a patch then drop any key whose value is empty/undefined —
+  // mirrors backend behavior (empty filter = no narrowing).
+  const update = (patch: Partial<ExtracurricularEventFilterParams>) => {
+    const next: ExtracurricularEventFilterParams = { ...value, ...patch }
+    ;(Object.keys(next) as (keyof ExtracurricularEventFilterParams)[]).forEach((key) => {
+      const v = next[key]
+      if (v === undefined || v === '' || v === null) delete next[key]
+    })
+    onChange(next)
+  }
+
+  return (
+    <div className={cn('flex flex-col gap-3 sm:flex-row sm:items-end sm:flex-wrap', className)}>
+      <div className="w-full sm:w-44">
+        <label
+          htmlFor="ext-filter-status"
+          className="block text-xs font-medium text-muted-foreground mb-1"
+        >
+          {t('status.label')}
+        </label>
+        <select
+          id="ext-filter-status"
+          aria-label={t('status.label')}
+          value={value.status ?? ''}
+          onChange={(e) =>
+            update({ status: (e.target.value || undefined) as EventStatus | undefined })
+          }
+          className={SELECT_CLASS}
+        >
+          <option value="">{t('status.all')}</option>
+          {EVENT_STATUSES.map((s) => (
+            <option key={s} value={s}>
+              {t(`status.${s}`)}
+            </option>
+          ))}
+        </select>
+      </div>
+
+      <div className="w-full sm:w-44">
+        <label
+          htmlFor="ext-filter-category"
+          className="block text-xs font-medium text-muted-foreground mb-1"
+        >
+          {t('category.label')}
+        </label>
+        <select
+          id="ext-filter-category"
+          aria-label={t('category.label')}
+          value={value.category ?? ''}
+          onChange={(e) =>
+            update({ category: (e.target.value || undefined) as EventCategory | undefined })
+          }
+          className={SELECT_CLASS}
+        >
+          <option value="">{t('category.all')}</option>
+          {EVENT_CATEGORIES.map((c) => (
+            <option key={c} value={c}>
+              {t(`category.${c}`)}
+            </option>
+          ))}
+        </select>
+      </div>
+    </div>
+  )
 }

--- a/frontend/src/components/extracurricular/ExtracurricularEventFilters.tsx
+++ b/frontend/src/components/extracurricular/ExtracurricularEventFilters.tsx
@@ -1,0 +1,15 @@
+'use client'
+
+// Stub — replaced in GREEN.
+
+import type { ExtracurricularEventFilterParams } from '@/types/extracurricular'
+
+export interface ExtracurricularEventFiltersProps {
+  value: ExtracurricularEventFilterParams
+  onChange: (next: ExtracurricularEventFilterParams) => void
+}
+
+export function ExtracurricularEventFilters(_props: ExtracurricularEventFiltersProps) {
+  void _props
+  return null
+}

--- a/frontend/src/components/extracurricular/__tests__/ExtracurricularEventCard.test.tsx
+++ b/frontend/src/components/extracurricular/__tests__/ExtracurricularEventCard.test.tsx
@@ -1,0 +1,119 @@
+import { render, screen, fireEvent } from '@testing-library/react'
+import { NextIntlClientProvider } from 'next-intl'
+import { ExtracurricularEventCard } from '../ExtracurricularEventCard'
+import ruMessages from '../../../../messages/ru.json'
+import type { ExtracurricularEventSummary } from '@/types/extracurricular'
+
+const baseEvent: ExtracurricularEventSummary = {
+  id: 7,
+  title: 'Spring concert',
+  category: 'cultural',
+  target_audience: 'all',
+  status: 'published',
+  location: 'Main hall',
+  start_at: '2026-06-15T18:00:00Z',
+  end_at: '2026-06-15T21:00:00Z',
+  max_capacity: 200,
+  organizer_id: 5,
+  participant_count: 42,
+  version: 3,
+  created_at: '2026-05-20T10:00:00Z',
+  updated_at: '2026-05-25T12:00:00Z',
+}
+
+function renderWith(node: React.ReactNode) {
+  return render(
+    <NextIntlClientProvider locale="ru" messages={ruMessages}>
+      {node}
+    </NextIntlClientProvider>
+  )
+}
+
+describe('ExtracurricularEventCard', () => {
+  it('renders event title', () => {
+    renderWith(<ExtracurricularEventCard event={baseEvent} />)
+    expect(screen.getByText('Spring concert')).toBeInTheDocument()
+  })
+
+  it('renders status badge with localized label', () => {
+    renderWith(<ExtracurricularEventCard event={baseEvent} />)
+    // ru.json: extracurricular.status.published = "Опубликовано"
+    expect(screen.getByText('Опубликовано')).toBeInTheDocument()
+  })
+
+  it('renders category badge with localized label', () => {
+    renderWith(<ExtracurricularEventCard event={baseEvent} />)
+    // ru.json: extracurricular.category.cultural = "Культурное"
+    expect(screen.getByText('Культурное')).toBeInTheDocument()
+  })
+
+  it('renders audience badge with localized label', () => {
+    renderWith(<ExtracurricularEventCard event={baseEvent} />)
+    // ru.json: extracurricular.audience.all = "Все"
+    expect(screen.getByText('Все')).toBeInTheDocument()
+  })
+
+  it('renders location text', () => {
+    renderWith(<ExtracurricularEventCard event={baseEvent} />)
+    expect(screen.getByText(/Main hall/i)).toBeInTheDocument()
+  })
+
+  it('renders participant count and capacity', () => {
+    renderWith(<ExtracurricularEventCard event={baseEvent} />)
+    expect(screen.getByText(/42/)).toBeInTheDocument()
+    expect(screen.getByText(/200/)).toBeInTheDocument()
+  })
+
+  it('omits capacity when max_capacity is null/undefined', () => {
+    renderWith(
+      <ExtracurricularEventCard
+        event={{ ...baseEvent, max_capacity: null, participant_count: 5 }}
+      />
+    )
+    expect(screen.getByText(/5/)).toBeInTheDocument()
+    expect(screen.queryByText(/200/)).not.toBeInTheDocument()
+  })
+
+  it('calls onClick when the title is clicked', () => {
+    const onClick = jest.fn()
+    renderWith(<ExtracurricularEventCard event={baseEvent} onClick={onClick} />)
+    fireEvent.click(screen.getByText('Spring concert'))
+    expect(onClick).toHaveBeenCalledTimes(1)
+  })
+
+  it('renders Register action when onRegister provided and not registered', () => {
+    const onRegister = jest.fn()
+    renderWith(<ExtracurricularEventCard event={baseEvent} onRegister={onRegister} />)
+    const btn = screen.getByText('Записаться')
+    fireEvent.click(btn)
+    expect(onRegister).toHaveBeenCalledTimes(1)
+  })
+
+  it('renders Unregister action instead of Register when isRegistered=true', () => {
+    const onUnregister = jest.fn()
+    renderWith(
+      <ExtracurricularEventCard
+        event={baseEvent}
+        onRegister={jest.fn()}
+        onUnregister={onUnregister}
+        isRegistered
+      />
+    )
+    expect(screen.queryByText('Записаться')).not.toBeInTheDocument()
+    const btn = screen.getByText('Отменить запись')
+    fireEvent.click(btn)
+    expect(onUnregister).toHaveBeenCalledTimes(1)
+  })
+
+  it('shows dropdown menu trigger when edit/delete handlers supplied', () => {
+    renderWith(
+      <ExtracurricularEventCard event={baseEvent} onEdit={jest.fn()} onDelete={jest.fn()} />
+    )
+    expect(screen.getByTestId('event-card-menu-trigger')).toBeInTheDocument()
+  })
+
+  it('omits dropdown menu trigger when no actions supplied', () => {
+    renderWith(<ExtracurricularEventCard event={baseEvent} />)
+    expect(screen.queryByTestId('event-card-menu-trigger')).not.toBeInTheDocument()
+  })
+})

--- a/frontend/src/components/extracurricular/__tests__/ExtracurricularEventCard.test.tsx
+++ b/frontend/src/components/extracurricular/__tests__/ExtracurricularEventCard.test.tsx
@@ -1,8 +1,10 @@
 import { render, screen, fireEvent } from '@testing-library/react'
-import { NextIntlClientProvider } from 'next-intl'
 import { ExtracurricularEventCard } from '../ExtracurricularEventCard'
-import ruMessages from '../../../../messages/ru.json'
 import type { ExtracurricularEventSummary } from '@/types/extracurricular'
+
+// next-intl is auto-mocked in jest.setup.ts: useTranslations returns
+// the key verbatim. Parity test loads real JSON for translations —
+// see hooks/__tests__/extracurricular.i18n.test.ts.
 
 const baseEvent: ExtracurricularEventSummary = {
   id: 7,
@@ -21,77 +23,65 @@ const baseEvent: ExtracurricularEventSummary = {
   updated_at: '2026-05-25T12:00:00Z',
 }
 
-function renderWith(node: React.ReactNode) {
-  return render(
-    <NextIntlClientProvider locale="ru" messages={ruMessages}>
-      {node}
-    </NextIntlClientProvider>
-  )
-}
-
 describe('ExtracurricularEventCard', () => {
   it('renders event title', () => {
-    renderWith(<ExtracurricularEventCard event={baseEvent} />)
+    render(<ExtracurricularEventCard event={baseEvent} />)
     expect(screen.getByText('Spring concert')).toBeInTheDocument()
   })
 
-  it('renders status badge with localized label', () => {
-    renderWith(<ExtracurricularEventCard event={baseEvent} />)
-    // ru.json: extracurricular.status.published = "Опубликовано"
-    expect(screen.getByText('Опубликовано')).toBeInTheDocument()
+  it('renders status badge (key — t-mock verbatim)', () => {
+    render(<ExtracurricularEventCard event={baseEvent} />)
+    expect(screen.getByText('status.published')).toBeInTheDocument()
   })
 
-  it('renders category badge with localized label', () => {
-    renderWith(<ExtracurricularEventCard event={baseEvent} />)
-    // ru.json: extracurricular.category.cultural = "Культурное"
-    expect(screen.getByText('Культурное')).toBeInTheDocument()
+  it('renders category badge', () => {
+    render(<ExtracurricularEventCard event={baseEvent} />)
+    expect(screen.getByText('category.cultural')).toBeInTheDocument()
   })
 
-  it('renders audience badge with localized label', () => {
-    renderWith(<ExtracurricularEventCard event={baseEvent} />)
-    // ru.json: extracurricular.audience.all = "Все"
-    expect(screen.getByText('Все')).toBeInTheDocument()
+  it('renders audience badge', () => {
+    render(<ExtracurricularEventCard event={baseEvent} />)
+    expect(screen.getByText('audience.all')).toBeInTheDocument()
   })
 
   it('renders location text', () => {
-    renderWith(<ExtracurricularEventCard event={baseEvent} />)
+    render(<ExtracurricularEventCard event={baseEvent} />)
     expect(screen.getByText(/Main hall/i)).toBeInTheDocument()
   })
 
   it('renders participant count and capacity', () => {
-    renderWith(<ExtracurricularEventCard event={baseEvent} />)
-    expect(screen.getByText(/42/)).toBeInTheDocument()
-    expect(screen.getByText(/200/)).toBeInTheDocument()
+    render(<ExtracurricularEventCard event={baseEvent} />)
+    expect(screen.getByText('42 / 200')).toBeInTheDocument()
   })
 
   it('omits capacity when max_capacity is null/undefined', () => {
-    renderWith(
+    render(
       <ExtracurricularEventCard
         event={{ ...baseEvent, max_capacity: null, participant_count: 5 }}
       />
     )
-    expect(screen.getByText(/5/)).toBeInTheDocument()
-    expect(screen.queryByText(/200/)).not.toBeInTheDocument()
+    expect(screen.getByText('5')).toBeInTheDocument()
+    expect(screen.queryByText(/\/ 200/)).not.toBeInTheDocument()
   })
 
   it('calls onClick when the title is clicked', () => {
     const onClick = jest.fn()
-    renderWith(<ExtracurricularEventCard event={baseEvent} onClick={onClick} />)
+    render(<ExtracurricularEventCard event={baseEvent} onClick={onClick} />)
     fireEvent.click(screen.getByText('Spring concert'))
     expect(onClick).toHaveBeenCalledTimes(1)
   })
 
   it('renders Register action when onRegister provided and not registered', () => {
     const onRegister = jest.fn()
-    renderWith(<ExtracurricularEventCard event={baseEvent} onRegister={onRegister} />)
-    const btn = screen.getByText('Записаться')
+    render(<ExtracurricularEventCard event={baseEvent} onRegister={onRegister} />)
+    const btn = screen.getByText('register')
     fireEvent.click(btn)
     expect(onRegister).toHaveBeenCalledTimes(1)
   })
 
   it('renders Unregister action instead of Register when isRegistered=true', () => {
     const onUnregister = jest.fn()
-    renderWith(
+    render(
       <ExtracurricularEventCard
         event={baseEvent}
         onRegister={jest.fn()}
@@ -99,21 +89,19 @@ describe('ExtracurricularEventCard', () => {
         isRegistered
       />
     )
-    expect(screen.queryByText('Записаться')).not.toBeInTheDocument()
-    const btn = screen.getByText('Отменить запись')
+    expect(screen.queryByText('register')).not.toBeInTheDocument()
+    const btn = screen.getByText('unregister')
     fireEvent.click(btn)
     expect(onUnregister).toHaveBeenCalledTimes(1)
   })
 
   it('shows dropdown menu trigger when edit/delete handlers supplied', () => {
-    renderWith(
-      <ExtracurricularEventCard event={baseEvent} onEdit={jest.fn()} onDelete={jest.fn()} />
-    )
+    render(<ExtracurricularEventCard event={baseEvent} onEdit={jest.fn()} onDelete={jest.fn()} />)
     expect(screen.getByTestId('event-card-menu-trigger')).toBeInTheDocument()
   })
 
   it('omits dropdown menu trigger when no actions supplied', () => {
-    renderWith(<ExtracurricularEventCard event={baseEvent} />)
+    render(<ExtracurricularEventCard event={baseEvent} />)
     expect(screen.queryByTestId('event-card-menu-trigger')).not.toBeInTheDocument()
   })
 })

--- a/frontend/src/components/extracurricular/__tests__/ExtracurricularEventFilters.test.tsx
+++ b/frontend/src/components/extracurricular/__tests__/ExtracurricularEventFilters.test.tsx
@@ -1,0 +1,62 @@
+import { render, screen, fireEvent } from '@testing-library/react'
+import { ExtracurricularEventFilters } from '../ExtracurricularEventFilters'
+import type { ExtracurricularEventFilterParams } from '@/types/extracurricular'
+
+// next-intl auto-mocked — t returns key verbatim. Parity test in
+// hooks/__tests__/extracurricular.i18n.test.ts loads real JSON.
+
+describe('ExtracurricularEventFilters', () => {
+  it('renders status select containing all canonical statuses', () => {
+    const onChange = jest.fn()
+    render(<ExtracurricularEventFilters value={{}} onChange={onChange} />)
+    const select = screen.getByLabelText('status.label') as HTMLSelectElement
+    const optionValues = Array.from(select.options).map((o) => o.value)
+    expect(optionValues).toEqual(
+      expect.arrayContaining(['', 'draft', 'published', 'canceled', 'completed'])
+    )
+  })
+
+  it('renders category select containing all canonical categories', () => {
+    const onChange = jest.fn()
+    render(<ExtracurricularEventFilters value={{}} onChange={onChange} />)
+    const select = screen.getByLabelText('category.label') as HTMLSelectElement
+    const optionValues = Array.from(select.options).map((o) => o.value)
+    expect(optionValues).toEqual(
+      expect.arrayContaining(['', 'academic', 'cultural', 'sports', 'volunteer', 'professional'])
+    )
+  })
+
+  it('calls onChange with status patch', () => {
+    const onChange = jest.fn()
+    render(<ExtracurricularEventFilters value={{}} onChange={onChange} />)
+    fireEvent.change(screen.getByLabelText('status.label'), { target: { value: 'published' } })
+    expect(onChange).toHaveBeenCalledWith(expect.objectContaining({ status: 'published' }))
+  })
+
+  it('calls onChange with category patch', () => {
+    const onChange = jest.fn()
+    render(<ExtracurricularEventFilters value={{}} onChange={onChange} />)
+    fireEvent.change(screen.getByLabelText('category.label'), { target: { value: 'sports' } })
+    expect(onChange).toHaveBeenCalledWith(expect.objectContaining({ category: 'sports' }))
+  })
+
+  it('drops the filter when "all" (empty value) is selected', () => {
+    const onChange = jest.fn()
+    const value: ExtracurricularEventFilterParams = { status: 'draft', category: 'cultural' }
+    render(<ExtracurricularEventFilters value={value} onChange={onChange} />)
+    fireEvent.change(screen.getByLabelText('status.label'), { target: { value: '' } })
+    expect(onChange).toHaveBeenCalledWith(
+      expect.not.objectContaining({ status: expect.any(String) })
+    )
+  })
+
+  it('reflects current value in select state', () => {
+    const onChange = jest.fn()
+    const value: ExtracurricularEventFilterParams = { status: 'canceled', category: 'volunteer' }
+    render(<ExtracurricularEventFilters value={value} onChange={onChange} />)
+    const status = screen.getByLabelText('status.label') as HTMLSelectElement
+    const category = screen.getByLabelText('category.label') as HTMLSelectElement
+    expect(status.value).toBe('canceled')
+    expect(category.value).toBe('volunteer')
+  })
+})


### PR DESCRIPTION
## Scope — v0.165.0 pages, split half 1 (of 3)

Part of B3 Extracurricular frontend slice (#328). Stacked on top of PR #330 (i18n × 4 parity). After PR #330 merges, GitHub auto-retargets this PR base to main.

PR-2 was originally one PR (1115 LOC) — split into c1 / c2 / c3 to stay under PR-Size 1000 LOC gate.

## Deliverables (this PR, 713 LOC)

**`ExtracurricularEventCard`** — components/extracurricular/ExtracurricularEventCard.tsx (~190 LOC). 3 colored badges (status / category / audience), title button → onClick, meta row (location, start_at, capacity ratio), Register/Unregister toggle by isRegistered, optional dropdown menu (edit / status transitions / delete) gated by handler presence.

**`ExtracurricularEventFilters`** — components/extracurricular/ExtracurricularEventFilters.tsx (~84 LOC). Two native selects (status + category) driven by enum arrays. Patch helper drops empty/undefined keys.

**`app/extracurricular/page.tsx`** — list page with AppLayout, header + create button (non-student only per canCreateEvents helper), filters, loading/error/empty/grid states, card onClick → /extracurricular/[id].

**Tests** (25 cases) — 12 EventCard + 6 Filters + 7 page (mocked next/navigation + hook + authStore). Key-verbatim assertions per project i18n mock pattern (feedback_i18n_json_load_parity_test).

## TDD discipline

3 pairs:
- Pair 4 — EventCard RED `e4bb928c` → GREEN `b48a2f01`
- Pair 5 — Filters RED `b62519e6` → GREEN `f9628586`
- Pair 6 — List page RED `dfccd002` → GREEN `03f021b1`

## Definition of done (для this PR)

- [x] `npm test --testPathPattern=extracurricular` 25/25 green (these tests)
- [x] `prettier --check` clean
- [x] `eslint` clean
- [x] Pre-commit hook clean
- [x] 713 LOC < 1000 PR-Size gate (vs predecessor branch base)

## Next

PR-2c2 (detail page ~405 LOC, #TBD) → PR-2c3 (calendar page ~218 LOC) → PR-3 (widget + nav + notifications wiring + release v0.165.0).

Refs #328