### PR TITLE
feat(extracurricular): v0.165.0c2 — detail page (Register/Unregister + participants)

### DIFF
--- a/frontend/src/app/extracurricular/[id]/__tests__/page.test.tsx
+++ b/frontend/src/app/extracurricular/[id]/__tests__/page.test.tsx
@@ -1,0 +1,177 @@
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+
+const mockReplace = jest.fn()
+const mockPush = jest.fn()
+const mockBack = jest.fn()
+const mockParams = jest.fn()
+jest.mock('next/navigation', () => ({
+  useRouter: () => ({ replace: mockReplace, push: mockPush, back: mockBack }),
+  useParams: () => mockParams(),
+}))
+
+const mockUseAuthCheck = jest.fn()
+jest.mock('@/hooks/useAuth', () => ({
+  useAuthCheck: () => mockUseAuthCheck(),
+}))
+
+const mockUserStore = jest.fn()
+jest.mock('@/stores/authStore', () => ({
+  useAuthStore: (selector: (s: { user: { id: number; role: string } | null }) => unknown) =>
+    selector({ user: mockUserStore() }),
+}))
+
+jest.mock('@/components/layout', () => ({
+  AppLayout: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+}))
+
+const mockUseEvent = jest.fn()
+const mockRegister = jest.fn()
+const mockUnregister = jest.fn()
+const mockDelete = jest.fn()
+jest.mock('@/hooks/useExtracurricularEvents', () => ({
+  useExtracurricularEvent: (id: number | null) => mockUseEvent(id),
+  registerForExtracurricularEvent: (id: number) => mockRegister(id),
+  unregisterFromExtracurricularEvent: (id: number) => mockUnregister(id),
+  deleteExtracurricularEvent: (id: number) => mockDelete(id),
+  pickExtracurricularErrorKey: () => 'generic',
+}))
+
+jest.mock('sonner', () => ({
+  toast: { success: jest.fn(), error: jest.fn() },
+}))
+
+import ExtracurricularEventDetailPage from '../page'
+
+const studentAuth = {
+  user: { id: 9, role: 'student' as const },
+  isAuthenticated: true,
+  isLoading: false,
+}
+
+const baseEvent = {
+  id: 7,
+  title: 'Spring Concert',
+  description: 'Annual evening of music',
+  category: 'cultural' as const,
+  target_audience: 'all' as const,
+  status: 'published' as const,
+  location: 'Main hall',
+  start_at: '2026-06-15T18:00:00Z',
+  end_at: '2026-06-15T21:00:00Z',
+  max_capacity: 200,
+  organizer_id: 5,
+  participants: [
+    { user_id: 9, registered_at: '2026-05-20T10:00:00Z' },
+    { user_id: 12, registered_at: '2026-05-21T10:00:00Z' },
+  ],
+  participant_count: 2,
+  version: 3,
+  created_at: '2026-05-20T10:00:00Z',
+  updated_at: '2026-05-25T12:00:00Z',
+}
+
+beforeEach(() => {
+  mockReplace.mockClear()
+  mockPush.mockClear()
+  mockBack.mockClear()
+  mockParams.mockReturnValue({ id: '7' })
+  mockUseAuthCheck.mockReturnValue(studentAuth)
+  mockUserStore.mockReturnValue(studentAuth.user)
+  mockUseEvent.mockReturnValue({
+    event: baseEvent,
+    isLoading: false,
+    error: undefined,
+    mutate: jest.fn(),
+  })
+})
+
+describe('ExtracurricularEventDetailPage', () => {
+  it('renders event title', () => {
+    render(<ExtracurricularEventDetailPage />)
+    expect(screen.getByText('Spring Concert')).toBeInTheDocument()
+  })
+
+  it('renders event description', () => {
+    render(<ExtracurricularEventDetailPage />)
+    expect(screen.getByText('Annual evening of music')).toBeInTheDocument()
+  })
+
+  it('renders location', () => {
+    render(<ExtracurricularEventDetailPage />)
+    expect(screen.getByText(/Main hall/i)).toBeInTheDocument()
+  })
+
+  it('renders participant count / capacity', () => {
+    render(<ExtracurricularEventDetailPage />)
+    expect(screen.getByText(/2 \/ 200/)).toBeInTheDocument()
+  })
+
+  it('shows loading spinner during fetch', () => {
+    mockUseEvent.mockReturnValue({
+      event: undefined,
+      isLoading: true,
+      error: undefined,
+      mutate: jest.fn(),
+    })
+    const { container } = render(<ExtracurricularEventDetailPage />)
+    expect(container.querySelector('.animate-spin')).toBeInTheDocument()
+  })
+
+  it('shows error state on fetch failure', () => {
+    mockUseEvent.mockReturnValue({
+      event: undefined,
+      isLoading: false,
+      error: new Error('boom'),
+      mutate: jest.fn(),
+    })
+    render(<ExtracurricularEventDetailPage />)
+    expect(screen.getByText('loadFailed')).toBeInTheDocument()
+  })
+
+  it('shows Unregister button when current user is in participants', () => {
+    render(<ExtracurricularEventDetailPage />)
+    expect(screen.getByText('unregister')).toBeInTheDocument()
+  })
+
+  it('shows Register button when current user not in participants', () => {
+    mockUserStore.mockReturnValue({ id: 42, role: 'student' as const })
+    mockUseAuthCheck.mockReturnValue({
+      user: { id: 42, role: 'student' as const },
+      isAuthenticated: true,
+      isLoading: false,
+    })
+    render(<ExtracurricularEventDetailPage />)
+    expect(screen.getByText('register')).toBeInTheDocument()
+  })
+
+  it('calls register mutation when Register clicked', async () => {
+    mockUserStore.mockReturnValue({ id: 42, role: 'student' as const })
+    mockUseAuthCheck.mockReturnValue({
+      user: { id: 42, role: 'student' as const },
+      isAuthenticated: true,
+      isLoading: false,
+    })
+    mockRegister.mockResolvedValue(undefined)
+    render(<ExtracurricularEventDetailPage />)
+    fireEvent.click(screen.getByText('register'))
+    await waitFor(() => expect(mockRegister).toHaveBeenCalledWith(7))
+  })
+
+  it('lists participants for non-student roles (organizer view)', () => {
+    mockUserStore.mockReturnValue({ id: 5, role: 'academic_secretary' as const })
+    mockUseAuthCheck.mockReturnValue({
+      user: { id: 5, role: 'academic_secretary' as const },
+      isAuthenticated: true,
+      isLoading: false,
+    })
+    render(<ExtracurricularEventDetailPage />)
+    // Participant rows render some marker для each user_id.
+    expect(screen.getByText(/user_id.*9/)).toBeInTheDocument()
+    expect(screen.getByText(/user_id.*12/)).toBeInTheDocument()
+  })
+
+  it('hides participants list for student viewers', () => {
+    render(<ExtracurricularEventDetailPage />)
+    expect(screen.queryByText(/user_id.*9/)).not.toBeInTheDocument()
+  })
+})

--- a/frontend/src/app/extracurricular/[id]/page.tsx
+++ b/frontend/src/app/extracurricular/[id]/page.tsx
@@ -1,6 +1,225 @@
 'use client'
 
-// Stub — replaced in GREEN.
+import { useState } from 'react'
+import { useParams, useRouter } from 'next/navigation'
+import { useTranslations } from 'next-intl'
+import { ArrowLeft, MapPin, Calendar as CalendarIcon, Users, Loader2 } from 'lucide-react'
+import { toast } from 'sonner'
+
+import { AppLayout } from '@/components/layout'
+import { Button } from '@/components/ui/button'
+import { cn } from '@/lib/utils'
+import {
+  useExtracurricularEvent,
+  registerForExtracurricularEvent,
+  unregisterFromExtracurricularEvent,
+  pickExtracurricularErrorKey,
+} from '@/hooks/useExtracurricularEvents'
+import type { EventCategory, EventStatus, EventTargetAudience } from '@/types/extracurricular'
+import { useAuthCheck } from '@/hooks/useAuth'
+import { useAuthStore } from '@/stores/authStore'
+
+const STATUS_COLORS: Record<EventStatus, string> = {
+  draft: 'bg-slate-100 text-slate-700 dark:bg-slate-800 dark:text-slate-300',
+  published: 'bg-emerald-100 text-emerald-700 dark:bg-emerald-900/40 dark:text-emerald-300',
+  canceled: 'bg-rose-100 text-rose-700 dark:bg-rose-900/40 dark:text-rose-300',
+  completed: 'bg-gray-100 text-gray-500 dark:bg-gray-900/40 dark:text-gray-400',
+}
+
+const CATEGORY_COLORS: Record<EventCategory, string> = {
+  academic: 'bg-blue-100 text-blue-700 dark:bg-blue-900/40 dark:text-blue-300',
+  cultural: 'bg-violet-100 text-violet-700 dark:bg-violet-900/40 dark:text-violet-300',
+  sports: 'bg-emerald-100 text-emerald-700 dark:bg-emerald-900/40 dark:text-emerald-300',
+  volunteer: 'bg-amber-100 text-amber-700 dark:bg-amber-900/40 dark:text-amber-300',
+  professional: 'bg-cyan-100 text-cyan-700 dark:bg-cyan-900/40 dark:text-cyan-300',
+}
+
+const AUDIENCE_COLORS: Record<EventTargetAudience, string> = {
+  all: 'bg-violet-100 text-violet-700 dark:bg-violet-900/40 dark:text-violet-300',
+  students: 'bg-blue-100 text-blue-700 dark:bg-blue-900/40 dark:text-blue-300',
+  teachers: 'bg-amber-100 text-amber-700 dark:bg-amber-900/40 dark:text-amber-300',
+  staff: 'bg-cyan-100 text-cyan-700 dark:bg-cyan-900/40 dark:text-cyan-300',
+}
+
+function canSeeParticipants(role: string | undefined): boolean {
+  return role !== undefined && role !== 'student'
+}
+
 export default function ExtracurricularEventDetailPage() {
-  return null
+  const t = useTranslations('extracurricular')
+  const params = useParams()
+  const router = useRouter()
+  useAuthCheck()
+  const user = useAuthStore((s) => s.user)
+
+  const idRaw = (params?.id as string | undefined) ?? null
+  const id = idRaw ? Number(idRaw) : null
+  const { event, isLoading, error, mutate } = useExtracurricularEvent(id)
+  const [busy, setBusy] = useState(false)
+
+  if (isLoading) {
+    return (
+      <AppLayout>
+        <div className="flex items-center justify-center py-24">
+          <Loader2 className="h-8 w-8 animate-spin text-muted-foreground" />
+        </div>
+      </AppLayout>
+    )
+  }
+
+  if (error || !event) {
+    return (
+      <AppLayout>
+        <div className="max-w-3xl mx-auto p-4 md:p-6">
+          <div className="rounded-xl bg-card border border-border p-8 text-center">
+            <p className="text-destructive font-medium">{t('loadFailed')}</p>
+            <Button
+              variant="outline"
+              className="mt-4"
+              onClick={() => router.push('/extracurricular')}
+            >
+              <ArrowLeft className="h-4 w-4 mr-2" />
+              {t('backToList')}
+            </Button>
+          </div>
+        </div>
+      </AppLayout>
+    )
+  }
+
+  const isRegistered = Boolean(user && event.participants?.some((p) => p.user_id === user.id))
+  const eventID = event.id
+
+  const handleRegister = async () => {
+    if (busy) return
+    setBusy(true)
+    try {
+      await registerForExtracurricularEvent(eventID)
+      await mutate()
+    } catch (err) {
+      toast.error(t(`errors.${pickExtracurricularErrorKey(err)}`))
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  const handleUnregister = async () => {
+    if (busy) return
+    setBusy(true)
+    try {
+      await unregisterFromExtracurricularEvent(eventID)
+      await mutate()
+    } catch (err) {
+      toast.error(t(`errors.${pickExtracurricularErrorKey(err)}`))
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  const showParticipants = canSeeParticipants(user?.role)
+
+  return (
+    <AppLayout>
+      <div className="max-w-3xl mx-auto p-4 md:p-6 space-y-6">
+        <Button variant="ghost" size="sm" onClick={() => router.push('/extracurricular')}>
+          <ArrowLeft className="h-4 w-4 mr-2" />
+          {t('backToList')}
+        </Button>
+
+        <div className="flex flex-wrap items-center gap-2">
+          <span
+            className={cn(
+              'text-[10px] font-semibold uppercase tracking-wide px-2 py-0.5 rounded-full',
+              STATUS_COLORS[event.status]
+            )}
+          >
+            {t(`status.${event.status}`)}
+          </span>
+          <span
+            className={cn(
+              'text-[10px] font-semibold uppercase tracking-wide px-2 py-0.5 rounded-full',
+              CATEGORY_COLORS[event.category]
+            )}
+          >
+            {t(`category.${event.category}`)}
+          </span>
+          <span
+            className={cn(
+              'text-[10px] font-semibold uppercase tracking-wide px-2 py-0.5 rounded-full',
+              AUDIENCE_COLORS[event.target_audience]
+            )}
+          >
+            {t(`audience.${event.target_audience}`)}
+          </span>
+        </div>
+
+        <h1 className="text-2xl md:text-3xl font-bold">{event.title}</h1>
+
+        {event.description && (
+          <p className="text-base text-muted-foreground whitespace-pre-line">{event.description}</p>
+        )}
+
+        <div className="grid grid-cols-1 sm:grid-cols-2 gap-3 text-sm">
+          {event.location && (
+            <div className="flex items-center gap-2">
+              <MapPin className="h-4 w-4 text-muted-foreground" />
+              <span>{event.location}</span>
+            </div>
+          )}
+          <div className="flex items-center gap-2">
+            <CalendarIcon className="h-4 w-4 text-muted-foreground" />
+            <span>
+              {t('startAt')}: {new Date(event.start_at).toLocaleString()}
+            </span>
+          </div>
+          <div className="flex items-center gap-2">
+            <CalendarIcon className="h-4 w-4 text-muted-foreground" />
+            <span>
+              {t('endAt')}: {new Date(event.end_at).toLocaleString()}
+            </span>
+          </div>
+          <div className="flex items-center gap-2">
+            <Users className="h-4 w-4 text-muted-foreground" />
+            <span>
+              {t('participants')}:{' '}
+              {event.max_capacity != null
+                ? `${event.participant_count} / ${event.max_capacity}`
+                : event.participant_count}
+            </span>
+          </div>
+        </div>
+
+        {event.status === 'published' && (
+          <div className="flex justify-end gap-2">
+            {isRegistered ? (
+              <Button variant="outline" disabled={busy} onClick={handleUnregister}>
+                {t('unregister')}
+              </Button>
+            ) : (
+              <Button disabled={busy} onClick={handleRegister}>
+                {t('register')}
+              </Button>
+            )}
+          </div>
+        )}
+
+        {showParticipants && event.participants && event.participants.length > 0 && (
+          <div className="space-y-2">
+            <h2 className="text-lg font-semibold">{t('participants')}</h2>
+            <ul className="space-y-1">
+              {event.participants.map((p) => (
+                <li key={p.user_id} className="text-sm flex items-center gap-2">
+                  <Users className="h-3.5 w-3.5 text-muted-foreground" />
+                  <span>user_id {p.user_id}</span>
+                  <span className="text-xs text-muted-foreground">
+                    {new Date(p.registered_at).toLocaleDateString()}
+                  </span>
+                </li>
+              ))}
+            </ul>
+          </div>
+        )}
+      </div>
+    </AppLayout>
+  )
 }

--- a/frontend/src/app/extracurricular/[id]/page.tsx
+++ b/frontend/src/app/extracurricular/[id]/page.tsx
@@ -1,0 +1,6 @@
+'use client'
+
+// Stub — replaced in GREEN.
+export default function ExtracurricularEventDetailPage() {
+  return null
+}


### PR DESCRIPTION
## Scope — v0.165.0 pages, split half 2 (of 3)

Stacked on top of PR-2c1 #331. Auto-retargets after upstream merge.

## Deliverables (this PR, 405 LOC)

**`app/extracurricular/[id]/page.tsx`** — detail page:
- Back-to-list + status/category/audience badges + title + description (whitespace-preserved)
- 2-column metadata grid (location, start_at, end_at, participants/capacity)
- Register/Unregister action visible only when event.status='published'; toggle by isRegistered (current user в participants list); pickExtracurricularErrorKey → toast on failure
- Participants list visible for non-student roles only (canSeeParticipants helper mirroring backend authz CanViewEvent matrix); hidden для student per privacy
- Loading / error states with back-button on error

**Tests** (11 cases) — mocked next/navigation/useParams + hook + authStore + sonner toast.

## TDD discipline

Pair 7 — RED `55b73f47` → GREEN `ec4858b6`. 11/11 pass.

## Definition of done

- [x] `npm test --testPathPattern='extracurricular/\[id\]'` 11/11 green
- [x] `prettier --check` + `eslint` clean
- [x] Pre-commit hook clean
- [x] 405 LOC < 1000 PR-Size gate

## Next

PR-2c3 (calendar ~218 LOC) → PR-3 (widget + nav + notifications wiring + release).

Refs #328