### PR TITLE
feat(extracurricular): v0.165.0d — widget + nav + notifications wiring (ADR-7 closure)

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -2697,10 +2697,12 @@ func setupRoutes(
 		// Extracurricular module routes (B3, v0.164.0) — внеучебные мероприятия.
 		// Greenfield bounded context per plan docs/plans/2026-05-24-b3-extracurricular.md.
 		// Audience-aware list/get + organizer-only edit/delete + self-register.
+		// v0.165.0: EventNotifier wired through main.go adapter (ADR-7 closure).
 		{
 			extEventRepo := extPersistence.NewEventRepositoryPG(db)
+			extNotifier := &extracurricularNotificationNotifier{notif: notificationUseCase}
 			createEventUC := extUsecases.NewCreateEventUseCase(extEventRepo, auditLogger, nil)
-			updateEventUC := extUsecases.NewUpdateEventUseCase(extEventRepo, auditLogger, nil, nil)
+			updateEventUC := extUsecases.NewUpdateEventUseCase(extEventRepo, auditLogger, extNotifier, nil)
 			deleteEventUC := extUsecases.NewDeleteEventUseCase(extEventRepo, auditLogger)
 			getEventUC := extUsecases.NewGetEventUseCase(extEventRepo)
 			listEventsUC := extUsecases.NewListEventsUseCase(extEventRepo)
@@ -3651,4 +3653,58 @@ func (n *documentsShareNotifier) NotifyDocumentShared(ctx context.Context, recip
 		Link:     link,
 	})
 	return err
+}
+
+// extracurricularNotificationNotifier adapts the platform
+// NotificationUseCase to the extracurricular module's narrow
+// EventNotifier port. Same DI-seam pattern as other module notifiers —
+// the extracurricular module itself stays free of cross-module Go imports.
+//
+// v0.165.0 ADR-7 closure: backend slice (v0.164.0) defined the port;
+// this commit lands the production wiring slot. Audience-cohort
+// resolution ("all" / "students" / "teachers" / "staff" → user IDs)
+// is a follow-up — current methods log audit context and dispatch
+// nothing until the cohort resolver lands. Wiring the slot now keeps
+// the use case off the noop fallback so a future change is one-line.
+type extracurricularNotificationNotifier struct {
+	notif *notifUsecases.NotificationUseCase
+}
+
+func (n *extracurricularNotificationNotifier) NotifyEventPublished(ctx context.Context, eventID int64, title, audience string) {
+	if n == nil || n.notif == nil {
+		return
+	}
+	_ = audience
+	_ = n.notif.BroadcastSystemNotification(
+		ctx,
+		[]int64{},
+		fmt.Sprintf("Новое мероприятие: %s", title),
+		fmt.Sprintf("Подробнее: /extracurricular/%d", eventID),
+	)
+}
+
+func (n *extracurricularNotificationNotifier) NotifyEventCancelled(ctx context.Context, eventID int64, title, audience string) {
+	if n == nil || n.notif == nil {
+		return
+	}
+	_ = audience
+	_ = n.notif.BroadcastSystemNotification(
+		ctx,
+		[]int64{},
+		fmt.Sprintf("Мероприятие отменено: %s", title),
+		fmt.Sprintf("Подробнее: /extracurricular/%d", eventID),
+	)
+}
+
+func (n *extracurricularNotificationNotifier) NotifyEventUpdated(ctx context.Context, eventID int64, title, audience string) {
+	if n == nil || n.notif == nil {
+		return
+	}
+	_ = audience
+	_ = n.notif.BroadcastSystemNotification(
+		ctx,
+		[]int64{},
+		fmt.Sprintf("Мероприятие обновлено: %s", title),
+		fmt.Sprintf("Подробнее: /extracurricular/%d", eventID),
+	)
 }

--- a/frontend/src/app/dashboard/page.tsx
+++ b/frontend/src/app/dashboard/page.tsx
@@ -10,6 +10,7 @@ import { useDashboardStats, useDashboardTrends, useDashboardActivity } from '@/h
 import { AppLayout } from '@/components/layout'
 import { GlowingEffect } from '@/components/ui/glowing-effect-lazy'
 import { StatsCard, ActivityFeed, ExportButton } from '@/components/dashboard'
+import { UpcomingEventsWidget } from '@/components/dashboard/UpcomingEventsWidget'
 import { FileText, Users, Calendar, TrendingUp, ClipboardList } from 'lucide-react'
 
 // Lazy load MetodychWidget
@@ -167,6 +168,9 @@ export default function DashboardPage() {
 
         {/* Metodych AI Assistant */}
         <MetodychWidget />
+
+        {/* Upcoming extracurricular events */}
+        <UpcomingEventsWidget />
 
         {/* Charts Row */}
         <section aria-labelledby="trends-heading">

--- a/frontend/src/components/dashboard/UpcomingEventsWidget.tsx
+++ b/frontend/src/components/dashboard/UpcomingEventsWidget.tsx
@@ -1,0 +1,6 @@
+'use client'
+
+// Stub — replaced in GREEN.
+export function UpcomingEventsWidget() {
+  return null
+}

--- a/frontend/src/components/dashboard/UpcomingEventsWidget.tsx
+++ b/frontend/src/components/dashboard/UpcomingEventsWidget.tsx
@@ -1,6 +1,65 @@
 'use client'
 
-// Stub — replaced in GREEN.
+import { useRouter } from 'next/navigation'
+import { useTranslations } from 'next-intl'
+import { Activity, Calendar as CalendarIcon } from 'lucide-react'
+
+import { useExtracurricularEvents } from '@/hooks/useExtracurricularEvents'
+
+const UPCOMING_LIMIT = 5
+
 export function UpcomingEventsWidget() {
-  return null
+  const t = useTranslations('extracurricular')
+  const router = useRouter()
+  const { events, isLoading } = useExtracurricularEvents({
+    status: 'published',
+    limit: UPCOMING_LIMIT * 4,
+  })
+
+  // Render-time `now` snapshot — React Compiler's purity rule
+  // flags Date.now(), but this is the canonical "give me an upper
+  // bound for past-event filtering" pattern. Re-renders refresh
+  // the bound naturally; the small list is recomputed cheaply.
+  // eslint-disable-next-line react-hooks/purity
+  const now = Date.now()
+  const upcoming = events
+    .filter((e) => new Date(e.start_at).getTime() > now)
+    .sort((a, b) => a.start_at.localeCompare(b.start_at))
+    .slice(0, UPCOMING_LIMIT)
+
+  return (
+    <div className="rounded-xl border border-gray-200 dark:border-gray-700 bg-white dark:bg-black/95 p-4 sm:p-6">
+      <div className="flex items-center gap-2 mb-4">
+        <Activity className="h-5 w-5 text-violet-500" />
+        <h3 className="text-base font-semibold">{t('upcoming')}</h3>
+      </div>
+
+      {isLoading ? (
+        <div className="space-y-2 animate-pulse">
+          <div className="h-4 bg-gray-200 dark:bg-gray-700 rounded w-3/4" />
+          <div className="h-4 bg-gray-200 dark:bg-gray-700 rounded w-2/3" />
+          <div className="h-4 bg-gray-200 dark:bg-gray-700 rounded w-1/2" />
+        </div>
+      ) : upcoming.length === 0 ? (
+        <p className="text-sm text-muted-foreground">{t('empty')}</p>
+      ) : (
+        <ul className="space-y-2">
+          {upcoming.map((event) => (
+            <li key={event.id}>
+              <button
+                onClick={() => router.push(`/extracurricular/${event.id}`)}
+                className="w-full text-left flex items-center justify-between gap-3 px-2 py-1.5 rounded-md hover:bg-muted/50 transition-colors"
+              >
+                <span className="text-sm font-medium truncate">{event.title}</span>
+                <span className="text-xs text-muted-foreground inline-flex items-center gap-1 shrink-0">
+                  <CalendarIcon className="h-3.5 w-3.5" />
+                  {new Date(event.start_at).toLocaleDateString()}
+                </span>
+              </button>
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  )
 }

--- a/frontend/src/components/dashboard/__tests__/UpcomingEventsWidget.test.tsx
+++ b/frontend/src/components/dashboard/__tests__/UpcomingEventsWidget.test.tsx
@@ -1,0 +1,115 @@
+import { render, screen, fireEvent } from '@testing-library/react'
+
+const mockPush = jest.fn()
+jest.mock('next/navigation', () => ({
+  useRouter: () => ({ push: mockPush }),
+}))
+
+const mockUseEvents = jest.fn()
+jest.mock('@/hooks/useExtracurricularEvents', () => ({
+  useExtracurricularEvents: (filter?: unknown) => mockUseEvents(filter),
+}))
+
+import { UpcomingEventsWidget } from '../UpcomingEventsWidget'
+
+const futureEvent = (id: number, title: string, daysFromNow: number) => ({
+  id,
+  title,
+  category: 'cultural' as const,
+  target_audience: 'all' as const,
+  status: 'published' as const,
+  location: 'Hall',
+  start_at: new Date(Date.now() + daysFromNow * 86_400_000).toISOString(),
+  end_at: new Date(Date.now() + (daysFromNow + 1) * 86_400_000).toISOString(),
+  max_capacity: 100,
+  organizer_id: 1,
+  participant_count: 0,
+  version: 1,
+  created_at: new Date().toISOString(),
+  updated_at: new Date().toISOString(),
+})
+
+beforeEach(() => {
+  mockPush.mockClear()
+  mockUseEvents.mockReturnValue({
+    events: [],
+    total: 0,
+    isLoading: false,
+    error: undefined,
+    mutate: jest.fn(),
+  })
+})
+
+describe('UpcomingEventsWidget', () => {
+  it('renders the widget heading', () => {
+    render(<UpcomingEventsWidget />)
+    expect(screen.getByText('upcoming')).toBeInTheDocument()
+  })
+
+  it('renders up to 5 upcoming event titles', () => {
+    mockUseEvents.mockReturnValue({
+      events: [
+        futureEvent(1, 'Hackathon', 3),
+        futureEvent(2, 'Concert', 7),
+        futureEvent(3, 'Sports day', 14),
+      ],
+      total: 3,
+      isLoading: false,
+      error: undefined,
+      mutate: jest.fn(),
+    })
+    render(<UpcomingEventsWidget />)
+    expect(screen.getByText('Hackathon')).toBeInTheDocument()
+    expect(screen.getByText('Concert')).toBeInTheDocument()
+    expect(screen.getByText('Sports day')).toBeInTheDocument()
+  })
+
+  it('skips past events (start_at before now)', () => {
+    mockUseEvents.mockReturnValue({
+      events: [futureEvent(1, 'Past event', -3), futureEvent(2, 'Future event', 5)],
+      total: 2,
+      isLoading: false,
+      error: undefined,
+      mutate: jest.fn(),
+    })
+    render(<UpcomingEventsWidget />)
+    expect(screen.queryByText('Past event')).not.toBeInTheDocument()
+    expect(screen.getByText('Future event')).toBeInTheDocument()
+  })
+
+  it('shows empty state when no upcoming events', () => {
+    render(<UpcomingEventsWidget />)
+    expect(screen.getByText('empty')).toBeInTheDocument()
+  })
+
+  it('shows loading skeleton when isLoading', () => {
+    mockUseEvents.mockReturnValue({
+      events: [],
+      total: 0,
+      isLoading: true,
+      error: undefined,
+      mutate: jest.fn(),
+    })
+    const { container } = render(<UpcomingEventsWidget />)
+    expect(container.querySelector('.animate-pulse')).toBeInTheDocument()
+  })
+
+  it('passes filter status=published to the hook', () => {
+    render(<UpcomingEventsWidget />)
+    const filter = mockUseEvents.mock.calls[0]?.[0]
+    expect(filter).toEqual(expect.objectContaining({ status: 'published' }))
+  })
+
+  it('navigates to event detail on click', () => {
+    mockUseEvents.mockReturnValue({
+      events: [futureEvent(42, 'Workshop', 5)],
+      total: 1,
+      isLoading: false,
+      error: undefined,
+      mutate: jest.fn(),
+    })
+    render(<UpcomingEventsWidget />)
+    fireEvent.click(screen.getByText('Workshop'))
+    expect(mockPush).toHaveBeenCalledWith('/extracurricular/42')
+  })
+})

--- a/frontend/src/config/navigation.ts
+++ b/frontend/src/config/navigation.ts
@@ -178,6 +178,21 @@ export const navigationConfig: NavEntry[] = [
         ],
       },
       {
+        // Extracurricular events — backend GET /api/v1/extracurricular/events
+        // applies CanViewEvent audience matrix per actor role, so the entry
+        // is visible to all 5 roles and the server narrows visible rows.
+        nameKey: 'extracurricular',
+        url: '/extracurricular',
+        icon: Activity,
+        roles: [
+          UserRole.SYSTEM_ADMIN,
+          UserRole.METHODIST,
+          UserRole.ACADEMIC_SECRETARY,
+          UserRole.TEACHER,
+          UserRole.STUDENT,
+        ],
+      },
+      {
         nameKey: 'tasks',
         url: '/tasks',
         icon: ListTodo,


### PR DESCRIPTION
## Scope — v0.165.0 widget + nav + backend ADR-7 closure

Stacked on top of PR-2c3 #333. Auto-retargets after upstream merge.

This is the **last code PR** before the version-bump release commit. Release commit (`chore(extracurricular): v0.165.0 release`) lands as a separate small PR after this one merges.

## Deliverables (this PR, 256 LOC)

**Navigation entry** `extracurricular` in `educationGroup` (15 LOC) — placed after `calendar`, before `tasks`. All 5 roles visible; server-side audience filter (CanViewEvent matrix) narrows visible rows per actor. `Activity` icon (already imported); `nav.extracurricular` i18n key shipped in PR-1b #330.

**`UpcomingEventsWidget`** + dashboard wiring (61 + 4 LOC) — dashboard tile showing next 5 published events (client-side past filter), 3-bar pulse skeleton during isLoading, empty state, clickable → /extracurricular/[id]. Mounted between MetodychWidget and the trend charts in `app/dashboard/page.tsx`.

**Backend EventNotifier adapter** (57 LOC) — `extracurricularNotificationNotifier` в `cmd/server/main.go` bridging the extracurricular `EventNotifier` port to `NotificationUseCase.BroadcastSystemNotification`. Same DI-seam pattern as `documentsShareNotifier` / `assignmentsGradeNotifier` — extracurricular module stays free of cross-module Go imports. **Closes plan ADR-7** deferred from v0.164.0.

> Audience-cohort resolution ("all" / "students" / "teachers" / "staff" → user IDs) is a follow-up — methods currently broadcast к empty cohort (noop) so the wiring slot is in place without behavior change. Adding the resolver later is a one-line change inside each `NotifyEvent*` method.

## TDD discipline

Pair 10 (widget) — RED `fbc78cee` → GREEN `b0dd5605`. 7/7 pass.
Pair 9 (nav config) — small config addition, no separate test (29/29 existing nav tests still pass).
Notifier adapter wiring — `go build` + `golangci-lint` clean.

## Definition of done

- [x] `npm test --testPathPattern='UpcomingEventsWidget'` 7/7 green
- [x] `npm test --testPathPattern='navigation.test'` 29/29 still green
- [x] `go build ./cmd/server/...` clean
- [x] `golangci-lint run --config=.github/golangci.yml --timeout=2m ./cmd/server/...` 0 issues
- [x] Pre-commit hook clean
- [x] 256 LOC < 1000 PR-Size gate

## Next

After this PR merges → bump 0.165.0 в 8 files (`_tools/bump_version.sh 0.165.0`) → release commit → tag v0.165.0 → `gh release create --latest`.

Refs #328