### PR TITLE
chore(ci): allow version-prefixed branches in PR metadata validation

### DIFF
--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -79,14 +79,21 @@ jobs:
         BRANCH_NAME="${{ github.head_ref }}"
         echo "Checking branch name: $BRANCH_NAME"
 
-        # Allowed patterns: feature/issue-N-description, task/issue-N-description, etc.
-        if [[ ! "$BRANCH_NAME" =~ ^(feature|task|bugfix|hotfix|config|chore|docs|refactor)/(issue-[0-9]+(\.[0-9]+)?-[a-z0-9-]+)$ ]]; then
+        # Allowed patterns:
+        #   <type>/issue-<N>-<desc>       e.g. feature/issue-123-user-auth
+        #   <type>/issue-<N.M>-<desc>     e.g. task/issue-2.1-go-module-setup
+        #   <type>/v<MAJOR.MINOR.PATCH>-<desc>  e.g. feature/v0.180.0-work-program-http
+        # The version-prefixed form is used for release-scoped work (one
+        # branch per minor/patch release) — the dominant convention in this
+        # repo. Both forms enforce a <type>/ prefix + descriptive slug.
+        if [[ ! "$BRANCH_NAME" =~ ^(feature|task|bugfix|hotfix|config|chore|docs|refactor)/((issue-[0-9]+(\.[0-9]+)?|v[0-9]+\.[0-9]+\.[0-9]+)-[a-z0-9-]+)$ ]]; then
           echo "❌ Invalid branch name format!"
-          echo "Expected format: <type>/issue-<number>-<description>"
+          echo "Expected format: <type>/issue-<number>-<description> OR <type>/v<major.minor.patch>-<description>"
           echo "Examples:"
           echo "  - feature/issue-123-user-authentication"
           echo "  - task/issue-2.1-go-module-setup"
           echo "  - bugfix/issue-456-login-validation"
+          echo "  - feature/v0.180.0-work-program-http"
           exit 1
         fi
         echo "✅ Branch name is valid"


### PR DESCRIPTION
## Summary
Extend the branch-naming regex in `.github/workflows/pr-validation.yml` (Validate PR Metadata) to accept `<type>/v<major.minor.patch>-<desc>` alongside the existing `<type>/issue-<N>-<desc>` form.

## Why
Release-scoped work in this repo uses one branch per minor/patch release (`feature/v0.X.Y-...`) — the dominant convention. The old regex only accepted `issue-N` references, so **every release branch soft-failed `Validate PR Metadata`** (precedent: #336, #351, #353). This removes that recurring false-negative while keeping the gate enforced.

## Behavior
Verified against positive + negative cases:
- ✅ `feature/v0.180.0-work-program-http`, `hotfix/v1.0.0-critical` (version form)
- ✅ `feature/issue-123-user-auth`, `task/issue-2.1-setup` (issue form, backward-compat)
- ❌ `feature/random-thing` (no issue/version anchor — still rejected)
- ❌ `feature/v0.180-missing-patch` (incomplete semver — rejected)
- ❌ `feature/V0.180.0-uppercase`, `feature/v0.180.0-` (malformed — rejected)

closes #352

## Test plan
- [x] Regex validated locally against 11 positive/negative branch names
- [ ] This PR's own `Validate PR Metadata` passes (branch `chore/issue-352-...` matches the existing form)