### PR TITLE
chore(ci): build cmd/server as package, not single file

### DIFF
--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -165,7 +165,7 @@ jobs:
     - name: Build server
       if: steps.check_gomod.outputs.exists == 'true'
       run: |
-        go build -v -o bin/server cmd/server/main.go
+        go build -v -o bin/server ./cmd/server
 
     - name: Verify binary
       if: steps.check_gomod.outputs.exists == 'true'


### PR DESCRIPTION
## Summary
The backend CI **Build** job compiled only `cmd/server/main.go` (single-file `go build`), which breaks the moment package `main` is split across more than one file — e.g. when a composition-root helper lives in its own file. The production `Dockerfile` already builds the whole package (`go build -o server ./cmd/server`); this aligns CI with it.

## Change
- `.github/workflows/backend-ci.yml`: `go build -v -o bin/server cmd/server/main.go` → `go build -v -o bin/server ./cmd/server`

## Why now
PR 5b (#364) adds `cmd/server/work_program_generation.go` (РПД generation wiring) to package `main`; the single-file Build step fails with `undefined: newDisciplineInfoAdapter`. Production builds it fine — only the CI command was wrong. No version bump (CI infra only).

## Test plan
- [ ] CI Build job green (self-validates the new command)